### PR TITLE
Explicitly initialise values used for testing

### DIFF
--- a/lib/test/types.cpp
+++ b/lib/test/types.cpp
@@ -1356,7 +1356,7 @@ TEST_CASE( "obname", "[type]" ) {
         bytes< 12 > v;
         const std::uint8_t idlen = 6;
         const void* end = dlis_obnameo( &v, originOut,
-                                            copynumber,
+                                            copynumberOut,
                                             idlen,
                                             identOut.c_str() );
 
@@ -1409,7 +1409,7 @@ TEST_CASE( "objref", "[type]" ) {
         const void* end = dlis_objrefo( &v, idlen,
                                             identOut.c_str(),
                                             originOut,
-                                            copynumber,
+                                            copynumberOut,
                                             idlen,
                                             identOut.c_str() );
 
@@ -1469,7 +1469,7 @@ TEST_CASE( "attref", "[type]" ) {
         const void* end = dlis_attrefo( &v, idlen,
                                             identOut.c_str(),
                                             originOut,
-                                            copynumber,
+                                            copynumberOut,
                                             idlen,
                                             identOut.c_str(),
                                             idlen,


### PR DESCRIPTION
Uninitialised varibles where used in the testsuite. However, as the
correct values where copied into the correct memoryspace by the previous
(to native) tests, the test still passed

Connects to #25 
Closes #25 