### PR TITLE
Widen short+norm to int in dlis_packf

### DIFF
--- a/lib/include/dlisio/dlisio.h
+++ b/lib/include/dlisio/dlisio.h
@@ -154,10 +154,10 @@ const char* dlis_component_str( int );
  * correct offset and memcpy'd into a typed variable.
  *
  * fmt is a sscanf-inspired format string of conversion specifiers
- * (DLIS_FMT_*). The size of each type depends on the most natural
- * corresponding C type, e.g. SSHORT is int8_t, and UNORM is uint16_t. The
- * arguments to a dlis_type() function in dlisio/types.h is the type being used
- * as a target type for a conversion specifier.
+ * (DLIS_FMT_*). The size of each type is widened to a reasonable corresponding
+ * C type, i.e. SSHORT is int, UNORM is unsigned int, ant SLONG is int32_t.
+ * The arguments to a dlis_type() function in dlisio/types.h is the type being
+ * used as a target type for a conversion specifier. UVARI outputs to int32_t.
  *
  * String types are always written as int32_t + len bytes, without a zero
  * terminator.
@@ -165,21 +165,21 @@ const char* dlis_component_str( int );
  * Example:
  *
  * Extracting a frame with three channels:
- * C1 -> 1x1 unorm (i16)
- * C2 -> 2x1 fsingle (f32)
- * C3 -> 1x1 uvari (yields i32)
+ * C1 -> 1x1 unorm (int)
+ * C2 -> 2x1 fsingle (float)
+ * C3 -> 1x1 uvari (yields int32_t)
  *
- * int16_t C1;
+ * int C1;
  * float C2[2];
  * int32_t C3;
  *
- * unsigned char bytes[2 + 2*4 + 4];
- * err = dlis_packf( "Uffi", src, bytes );
+ * unsigned char bytes[sizeof(C1) + sizeof(C2) + sizeof(C3)];
+ * err = dlis_packf("Uffi", src, bytes);
  * if (err) exit(1);
  *
- * memcpy( &C1, bytes, sizeof(C1) );
- * memcpy( C2, bytes + 2, sizeof(C2) );
- * memcpy( &c3, bytes + 10, sizeof(C3) );
+ * memcpy(&C1, bytes,      sizeof(C1));
+ * memcpy( C2, bytes + 4,  sizeof(C2));
+ * memcpy(&c3, bytes + 12, sizeof(C3));
  */
 int dlis_packf( const char* fmt, const void* src, void* dst );
 

--- a/lib/src/dlisio.cpp
+++ b/lib/src/dlisio.cpp
@@ -457,11 +457,21 @@ char* pack( char* dst ) noexcept (true) {
     return dst;
 }
 
+/*
+ * widen int8 and int16 types to int/uint, and keep every other size as-is
+ */
+template < typename T > struct widen      { using type = T; };
+template <> struct widen< std::int8_t >   { using type = int; };
+template <> struct widen< std::int16_t >  { using type = int; };
+template <> struct widen< std::uint8_t >  { using type = unsigned int; };
+template <> struct widen< std::uint16_t > { using type = unsigned int; };
+
 template < typename T, typename... Ts >
 char* pack( char* dst, const T* ptr, const Ts* ... ptrs ) noexcept (true) {
-    std::memcpy( dst, ptr, sizeof( T ) );
-    dst += sizeof( T );
-    return pack( dst, ptrs ... );
+    typename widen< T >::type tmp = *ptr;
+    std::memcpy(dst, &tmp, sizeof(tmp));
+    dst += sizeof(tmp);
+    return pack(dst, ptrs ...);
 }
 
 template < typename... Ts >
@@ -655,14 +665,14 @@ int dlis_pack_size( const char* fmt, int* size ) {
             case DLIS_FMT_FDOUB2: sz += sizeof(double) * 3;    break;
             case DLIS_FMT_CSINGL: sz += sizeof(float) * 2;     break;
             case DLIS_FMT_CDOUBL: sz += sizeof(double) * 2;    break;
-            case DLIS_FMT_SSHORT: sz += sizeof(std::int8_t);   break;
-            case DLIS_FMT_SNORM:  sz += sizeof(std::int16_t);  break;
+            case DLIS_FMT_SSHORT: sz += sizeof(int);           break;
+            case DLIS_FMT_SNORM:  sz += sizeof(int);           break;
             case DLIS_FMT_SLONG:  sz += sizeof(std::int32_t);  break;
-            case DLIS_FMT_USHORT: sz += sizeof(std::uint8_t);  break;
-            case DLIS_FMT_UNORM:  sz += sizeof(std::uint16_t); break;
+            case DLIS_FMT_USHORT: sz += sizeof(unsigned int);  break;
+            case DLIS_FMT_UNORM:  sz += sizeof(unsigned int);  break;
             case DLIS_FMT_ULONG:  sz += sizeof(std::uint32_t); break;
             case DLIS_FMT_DTIME:  sz += sizeof(int) * 8;       break;
-            case DLIS_FMT_STATUS: sz += sizeof(std::int8_t);   break;
+            case DLIS_FMT_STATUS: sz += sizeof(int);           break;
             case DLIS_FMT_ORIGIN: sz += sizeof(std::int32_t);  break;
             case DLIS_FMT_UVARI:  sz += sizeof(std::int32_t);  break;
 

--- a/lib/test/pack.cpp
+++ b/lib/test/pack.cpp
@@ -79,29 +79,32 @@ TEST_CASE_METHOD(check_packsize, "pack unsigned integers", "[pack]") {
     };
 
     fmt = "uuUULLiiiiiiiii";
-    buffer.resize((1 * 2) + (2 * 2) + (4 * 2) + (4 * 9));
+    buffer.resize(  (sizeof(unsigned) * 2)
+                  + (sizeof(unsigned) * 2)
+                  + (sizeof(std::uint32_t) * 2)
+                  + (sizeof(std::int32_t)  * 9));
     auto* dst = buffer.data();
 
     const auto err = dlis_packf( fmt, source, dst );
     CHECK( err == DLIS_OK );
 
-    std::uint8_t us[2];
+    unsigned int us[2];
     std::memcpy( us, dst, sizeof(us) );
     CHECK( us[ 0 ] == 89 );
     CHECK( us[ 1 ] == 167 );
 
-    std::uint16_t un[2];
-    std::memcpy( un, dst + 2, sizeof(un) );
+    unsigned int un[2];
+    std::memcpy( un, dst + 8, sizeof(un) );
     CHECK( un[ 0 ] == 153 );
     CHECK( un[ 1 ] == 32768 );
 
     std::uint32_t ul[2];
-    std::memcpy( ul, dst + 6, sizeof(ul) );
+    std::memcpy( ul, dst + 16, sizeof(ul) );
     CHECK( ul[ 0 ] == 153 );
     CHECK( ul[ 1 ] == 4294967143 );
 
     std::int32_t uv[9];
-    std::memcpy( uv, dst + 14, sizeof(uv) );
+    std::memcpy( uv, dst + 24, sizeof(uv) );
     CHECK( uv[ 0 ] == 1 );
     CHECK( uv[ 1 ] == 256 );
     CHECK( uv[ 2 ] == 36863 );
@@ -125,24 +128,26 @@ TEST_CASE_METHOD(check_packsize, "pack signed integers", "[pack]") {
     };
 
     fmt = "ddDDlll";
-    buffer.resize((1 * 2) + (2 * 2) + (4 * 3));
+    buffer.resize(  (sizeof(int) * 2)
+                  + (sizeof(int) * 2)
+                  + (sizeof(std::int32_t) * 3));
     auto* dst = buffer.data();
 
     const auto err = dlis_packf( fmt, source, dst );
     CHECK( err == DLIS_OK );
 
-    std::int8_t ss[2];
+    int ss[2];
     std::memcpy( ss, dst, sizeof( ss ) );
     CHECK( ss[ 0 ] == 89 );
     CHECK( ss[ 1 ] == -89 );
 
-    std::int16_t sn[2];
-    std::memcpy( sn, dst + 2, sizeof( sn ) );
+    int sn[2];
+    std::memcpy( sn, dst + 8, sizeof( sn ) );
     CHECK( sn[ 0 ] == 153 );
     CHECK( sn[ 1 ] == -153 );
 
     std::int32_t sl[3];
-    std::memcpy( sl, dst + 6, sizeof( sl ) );
+    std::memcpy( sl, dst + 16, sizeof( sl ) );
     CHECK( sl[ 0 ] == 153 );
     CHECK( sl[ 1 ] == -153 );
     CHECK( sl[ 2 ] == 2147483647 );
@@ -307,15 +312,18 @@ TEST_CASE_METHOD(check_packsize, "pack status", "[pack]") {
         0x01, // 1 status
     };
 
-    buffer.resize( 2 );
+    buffer.resize(sizeof(int) * 2);
     fmt = "qq";
     auto* dst = buffer.data();
 
     const auto err = dlis_packf( fmt, source, dst );
     CHECK( err == DLIS_OK );
 
-    CHECK( !dst[ 0 ] );
-    CHECK(  dst[ 1 ] );
+    int status[2];
+    std::memcpy(status, dst, buffer.size());
+
+    CHECK( !status[ 0 ] );
+    CHECK(  status[ 1 ] );
 }
 
 namespace {
@@ -453,7 +461,10 @@ TEST_CASE_METHOD(check_is_varsize, "pack obname", "[pack]") {
         0x44, 0x4C,
     };
 
-    std::vector< char > buffer( (4 + 1 + 16) + (4 + 1 + 6) );
+    std::vector< char > buffer(
+          (sizeof(std::int32_t) + sizeof(unsigned int) + 16)
+        + (sizeof(std::int32_t) + sizeof(unsigned int) + 6)
+    );
     fmt = "oo";
     auto* dst = buffer.data();
 
@@ -461,12 +472,12 @@ TEST_CASE_METHOD(check_is_varsize, "pack obname", "[pack]") {
     CHECK( err == DLIS_OK );
 
     std::int32_t origin;
-    std::uint8_t copy;
+    unsigned int copy;
     std::string id;
 
     std::memcpy( &origin, dst + 0, sizeof(origin) );
     std::memcpy( &copy,   dst + 4, sizeof(copy) );
-    id = readstr( dst + 5 );
+    id = readstr( dst + 4 + sizeof(unsigned int) );
     CHECK( origin == 314 );
     CHECK( copy == 255 );
     CHECK( id == "DLISIODLISIO" );
@@ -475,7 +486,7 @@ TEST_CASE_METHOD(check_is_varsize, "pack obname", "[pack]") {
 
     std::memcpy( &origin, dst + 0, sizeof(origin) );
     std::memcpy( &copy,   dst + 4, sizeof(copy) );
-    id = readstr( dst + 5 );
+    id = readstr( dst + 4 + sizeof(unsigned int) );
     CHECK( origin == 4 );
     CHECK( copy == 15 );
     CHECK( id == "DL" );
@@ -489,7 +500,10 @@ TEST_CASE_METHOD(check_is_varsize, "pack objref", "[pack]") {
         0x08, 0x50, 0x52, 0x4F, 0x54, 0x4F, 0x43, 0x4F, 0x4C, // "PROTOCOL"
     };
 
-    std::vector< char > buffer(4 + 7 + 4 + 1 + 4 + 8);
+    std::vector< char > buffer(
+          sizeof(std::int32_t) + 7
+        + sizeof(std::int32_t) + sizeof(int) + sizeof(std::int32_t) + 8
+    );
     auto* dst = buffer.data();
 
     fmt = "O";
@@ -498,13 +512,13 @@ TEST_CASE_METHOD(check_is_varsize, "pack objref", "[pack]") {
 
     std::string type;
     std::int32_t origin;
-    std::uint8_t copy;
+    unsigned int copy;
     std::string id;
 
     type = readstr( dst + 0 );
     std::memcpy( &origin, dst + 11, sizeof(origin) );
     std::memcpy( &copy,   dst + 15, sizeof(copy) );
-    id = readstr( dst + 16 );
+    id = readstr( dst + 15 + sizeof(unsigned int));
 
     CHECK( type == "LIBRARY" );
     CHECK( 1 == origin );
@@ -530,7 +544,12 @@ TEST_CASE_METHOD(check_is_varsize, "pack attref", "[pack]") {
     };
 
     fmt = "A";
-    std::vector< char > buffer( (4 + 10) + (4 + 1) + (4 + 12) + (4 + 13) );
+    std::vector< char > buffer(
+          (sizeof(std::int32_t) + 10)
+        + (sizeof(std::int32_t) + sizeof(unsigned int))
+        + (sizeof(std::int32_t) + 12)
+        + (sizeof(std::int32_t) + 13)
+    );
     auto* dst = buffer.data();
 
     const auto err = dlis_packf( fmt, source, dst );
@@ -538,15 +557,15 @@ TEST_CASE_METHOD(check_is_varsize, "pack attref", "[pack]") {
 
     std::string type;
     std::int32_t origin;
-    std::uint8_t copy;
+    unsigned int copy;
     std::string id;
     std::string label;
 
     type = readstr( dst + 0 );
     std::memcpy( &origin, dst + 14, sizeof(origin) );
     std::memcpy( &copy,   dst + 18, sizeof(copy) );
-    id = readstr( dst + 19 );
-    label = readstr( dst + 35 );
+    id = readstr( dst + 18 + sizeof(unsigned int));
+    label = readstr( dst + 34 + sizeof(unsigned int));
 
     CHECK( type == "LOREMIPSUM" ) ;
     CHECK( origin == 10 );
@@ -561,14 +580,21 @@ TEST_CASE_METHOD(check_is_varsize, "pack unexpected value", "[pack]") {
         0x01, 0x53, // "S" ident
     };
 
-    unsigned char dst[6];
+    unsigned char dst[10];
     fmt = "ust";
 
     const auto err = dlis_packf( fmt, source, dst );
 
-    CHECK( err == DLIS_UNEXPECTED_VALUE);
-    CHECK( dst[0] == 89);
-    CHECK( dst[5] == 'S');
+    int n;
+    std::int32_t len;
+
+    std::memcpy(&n, dst, sizeof(n));
+    std::memcpy(&len, dst + sizeof(n), sizeof(len));
+
+    CHECK(err == DLIS_UNEXPECTED_VALUE);
+    CHECK(n == 89);
+    CHECK(len == 1);
+    CHECK(dst[sizeof(n) + sizeof(len)] == 'S');
 }
 
 TEST_CASE("pack var-size fails with invalid specifier") {
@@ -647,14 +673,14 @@ TEST_CASE("pack size single values") {
     CHECK( packsize( "Z" ) == 24 );
     CHECK( packsize( "c" ) == 8 );
     CHECK( packsize( "C" ) == 16 );
-    CHECK( packsize( "d" ) == 1 );
-    CHECK( packsize( "D" ) == 2 );
+    CHECK( packsize( "d" ) == sizeof(int) );
+    CHECK( packsize( "D" ) == sizeof(int) );
     CHECK( packsize( "l" ) == 4 );
-    CHECK( packsize( "u" ) == 1 );
-    CHECK( packsize( "U" ) == 2 );
+    CHECK( packsize( "u" ) == sizeof(unsigned) );
+    CHECK( packsize( "U" ) == sizeof(unsigned) );
     CHECK( packsize( "L" ) == 4 );
     CHECK( packsize( "i" ) == 4 );
     CHECK( packsize( "j" ) == 32 );
     CHECK( packsize( "J" ) == 4 );
-    CHECK( packsize( "q" ) == 1 );
+    CHECK( packsize( "q" ) == sizeof(int) );
 }


### PR DESCRIPTION
Widen shorter integral types (*SHORT, *NORM) to int, so that
higher-level layers have to deal with fewer impractical non-int
integrals.