### PR TITLE
Cleanup error-messages from fingerprint-functions

### DIFF
--- a/lib/include/dlisio/dlisio.h
+++ b/lib/include/dlisio/dlisio.h
@@ -494,12 +494,13 @@ int dlis_index_records( const char* begin,
  * The len function returns the length of the fingerprint in bytes on success,
  * negative otherwise.
  */
-int dlis_object_fingerprint_len(int32_t type_len,
-                                const char* type,
-                                int32_t id_len,
-                                const char* id,
-                                int32_t origin,
-                                uint8_t copynum);
+int dlis_object_fingerprint_size(int32_t type_len,
+                                 const char* type,
+                                 int32_t id_len,
+                                 const char* id,
+                                 int32_t origin,
+                                 uint8_t copynum,
+                                 int* size);
 
 int dlis_object_fingerprint(int32_t type_len,
                             const char* type,

--- a/lib/src/dlisio.cpp
+++ b/lib/src/dlisio.cpp
@@ -902,26 +902,27 @@ int dlis_index_records( const char* begin,
     }
 }
 
-int dlis_object_fingerprint_len(std::int32_t type_len,
-                                const char*,
-                                std::int32_t id_len,
-                                const char*,
-                                std::int32_t origin,
-                                std::uint8_t copynum) {
+int dlis_object_fingerprint_size(std::int32_t type_len,
+                                 const char*,
+                                 std::int32_t id_len,
+                                 const char*,
+                                 std::int32_t origin,
+                                 std::uint8_t copynum,
+                                 int* size) {
 
-    if (origin < 0) return -1;
+    if (origin < 0)    return DLIS_INVALID_ARGS;
+    if (type_len <= 0) return DLIS_INVALID_ARGS;
+    if (id_len <= 0)   return DLIS_INVALID_ARGS;
 
     const auto orig_len = std::to_string(origin).length();
     const auto copy_len = std::to_string(copynum).length();
 
-    if (type_len <= 0) return -2;
-    if (id_len <= 0)   return -3;
-    if (origin < 0)  return -4;
 
     // each element, except the last one, add a constant 3 characters currently,
     // so return len*3 this might change in the future, and the contents of
     // type+id might matter, so keep the params around
-    return 11 + type_len + id_len + orig_len + copy_len;
+    *size =  11 + type_len + id_len + orig_len + copy_len;
+    return DLIS_OK;
 }
 
 int dlis_object_fingerprint(std::int32_t type_len,

--- a/lib/src/parse.cpp
+++ b/lib/src/parse.cpp
@@ -573,27 +573,29 @@ const noexcept (false) {
     const auto& copy = dl::decay(this->copy);
     const auto& id = dl::decay(this->id);
 
-    auto len = dlis_object_fingerprint_len(type.size(),
-                                           type.data(),
-                                           id.size(),
-                                           id.data(),
-                                           origin,
-                                           copy);
+    int size;
+    auto err = dlis_object_fingerprint_size(type.size(),
+                                            type.data(),
+                                            id.size(),
+                                            id.data(),
+                                            origin,
+                                            copy,
+                                            &size);
 
-    // TODO: investigate what went wrong here
-    if (len <= 0)
-        throw std::invalid_argument("fingerprint");
+    if (err)
+        throw std::invalid_argument("invalid argument");
 
-    auto str = std::vector< char >(len);
-    auto err = dlis_object_fingerprint(type.size(),
-                                       type.data(),
-                                       id.size(),
-                                       id.data(),
-                                       origin,
-                                       copy,
-                                       str.data());
+    auto str = std::vector< char >(size);
+    err = dlis_object_fingerprint(type.size(),
+                                  type.data(),
+                                  id.size(),
+                                  id.data(),
+                                  origin,
+                                  copy,
+                                  str.data());
 
-    if (err) throw std::runtime_error("fingerprint: something went wrong");
+    if (err)
+        throw std::runtime_error("fingerprint: something went wrong");
 
     return std::string(str.begin(), str.end());
 }

--- a/lib/test/protocol.cpp
+++ b/lib/test/protocol.cpp
@@ -467,18 +467,21 @@ TEST_CASE("fingerprint length matches bytes written") {
     auto origin = 0;
     auto copy = 0;
 
-    auto len = dlis_object_fingerprint_len(
+    int size;
+    auto err = dlis_object_fingerprint_size(
         type.size(),
         type.data(),
         id.size(),
         id.data(),
         origin,
-        copy);
+        copy,
+        &size);
 
-    CHECK(len > 0);
+    CHECK(!err);
+    CHECK(size > 0);
 
     std::vector< char > buffer(1024, 0);
-    auto err = dlis_object_fingerprint(
+    err = dlis_object_fingerprint(
         type.size(),
         type.data(),
         id.size(),
@@ -490,7 +493,47 @@ TEST_CASE("fingerprint length matches bytes written") {
     CHECK(!err);
 
     auto fingerprint = std::string(buffer.data());
-    CHECK(fingerprint.size() == len);
+    CHECK(fingerprint.size() == size);
+}
+
+TEST_CASE("fingerprint fails on empty string") {
+    SECTION("type is empty") {
+        std::string type = "";
+        std::string id = "IDENT";
+        auto origin = 0;
+        auto copy = 0;
+
+        std::vector< char > buffer(1024, 0);
+        auto err = dlis_object_fingerprint(
+            type.size(),
+            type.data(),
+            id.size(),
+            id.data(),
+            origin,
+            copy,
+            buffer.data());
+
+        CHECK( err == DLIS_INVALID_ARGS );
+    };
+
+    SECTION("id is empty") {
+        std::string type = "CHANNEL";
+        std::string id = "";
+        auto origin = 0;
+        auto copy = 0;
+
+        std::vector< char > buffer(1024, 0);
+        auto err = dlis_object_fingerprint(
+            type.size(),
+            type.data(),
+            id.size(),
+            id.data(),
+            origin,
+            copy,
+            buffer.data());
+
+        CHECK( err == DLIS_INVALID_ARGS );
+    };
 }
 
 namespace {

--- a/python/dlisio/ext/core.cpp
+++ b/python/dlisio/ext/core.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <limits>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
@@ -237,11 +238,21 @@ py::dict storage_label( py::buffer b ) {
 std::string fingerprint(const std::string& type,
                         const std::string& id,
                         std::int32_t origin,
-                        std::uint8_t copy) {
+                        std::int32_t copy) {
+
+    std::string msg = "Invalid argument, copy out of range";
+    if ( copy > (std::numeric_limits< std::uint8_t >::max)() )
+        throw std::invalid_argument( msg );
+
+    if ( copy < (std::numeric_limits< std::uint8_t >::min)() )
+        throw std::invalid_argument( msg );
+
+    const auto ucopy = std::uint8_t(copy);
+
     dl::objref ref;
     ref.type = dl::ident{ type };
     ref.name.origin = dl::origin{ origin };
-    ref.name.copy = dl::ushort{ copy };
+    ref.name.copy = dl::ushort{ ucopy };
     ref.name.id = dl::ident{ id };
     return ref.fingerprint();
 }

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -180,6 +180,21 @@ def test_objects(DWL206):
     objects = DWL206.objects
     assert len(list(objects)) == 864
 
+def test_fingerprint():
+    reference = "T.FRAME-I.800T-O.2-C.46"
+    key = dlisio.core.fingerprint("FRAME", "800T", 2, 46)
+    assert key == reference
+
+def test_fingerprint_invalid_argument():
+    with pytest.raises(ValueError):
+        _ = dlisio.core.fingerprint("", "800T", 2, 46)
+    with pytest.raises(ValueError):
+        _ = dlisio.core.fingerprint("FRAME", "", 2, 46)
+    with pytest.raises(ValueError):
+        _ = dlisio.core.fingerprint("FRAME", "800T", -1, 46)
+    with pytest.raises(ValueError):
+        _ = dlisio.core.fingerprint("FRAME", "800T", 2, -1)
+
 def test_fileheader(DWL206):
     key = dlisio.core.fingerprint('FILE-HEADER', '5', 2, 0)
     fh = DWL206.objects[key]


### PR DESCRIPTION
Refactor the fingerprint functions so that they produce coherrent error
messages. As a part of this, add some tests and do minor refactoring.