### PR TITLE
Re-format dtype.names on duplicate mnemonics

### DIFF
--- a/python/dlisio/plumbing/basicobject.py
+++ b/python/dlisio/plumbing/basicobject.py
@@ -21,8 +21,8 @@ class BasicObject():
 
         try:
             self.name       = name.id
-            self.origin     = name.origin
-            self.copynumber = name.copynumber
+            self.origin     = int(name.origin)
+            self.copynumber = int(name.copynumber)
         except AttributeError:
             pass
 

--- a/python/tests/test_frames.py
+++ b/python/tests/test_frames.py
@@ -15,3 +15,31 @@ def test_frame_getitem(DWL206):
 
     assert curves['TDEP'][0] == 852606.0
     assert curves[0]['TDEP'] == 852606.0
+
+def test_duplicated_mnemonics_gets_unique_labels():
+    time0 = dlisio.plumbing.Channel()
+    time0.name = 'TIME'
+    time0.origin = 0
+    time0.copynumber = 0
+    time0.dimension = [1]
+    time0.reprc = 2 # f4
+
+    tdep = dlisio.plumbing.Channel()
+    tdep.name = 'TDEP'
+    tdep.origin = 0
+    tdep.copynumber = 0
+    tdep.dimension = [2]
+    tdep.reprc = 13 # i2
+
+    time1 = dlisio.plumbing.Channel()
+    time1.name = 'TIME'
+    time1.origin = 1
+    time1.copynumber = 0
+    time1.dimension = [1]
+    time1.reprc = 13 # i2
+
+    frame = dlisio.plumbing.Frame()
+    frame.channels = [time0, tdep, time1]
+
+    assert 'fDDD' == frame.fmtstr()
+    assert ('TIME:0:0', 'TDEP', 'TIME:1:0') == frame.dtype.names


### PR DESCRIPTION
When a frame has multiple channels with the same name, enrich the label
by adding :origin:copynumber, so that all names given to numpy.dtype are
unique. This is already the built-in disambiguation mechanism of RP66.

This addition is not done by default because for the cases with only one
mnemonic for the frame, the added formatting is obnoxious and
unnecessary.

Closes #95 