### PR TITLE
Use . for mnemonic-origin-copy separator in dtype

### DIFF
--- a/python/dlisio/plumbing/frame.py
+++ b/python/dlisio/plumbing/frame.py
@@ -89,7 +89,7 @@ class Frame(BasicObject):
 
         Consider a frame with the channels mnemonics [('TIME', 0, 0), ('TDEP',
         0, 0), ('TIME, 1, 0)]. The dtype names for this frame would be
-        ('TIME:0:0', 'TDEP', 'TIME:1:0').
+        ('TIME.0.0', 'TDEP', 'TIME.1.0').
 
         See also
         --------
@@ -112,7 +112,7 @@ class Frame(BasicObject):
         msg = ', '.join((source, problem))
         info = 'name = {}, origin = {}, copynumber = {}'.format
 
-        fmtlabel = '{:s}:{:d}:{:d}'.format
+        fmtlabel = '{:s}.{:d}.{:d}'.format
         for i, ch in enumerate(self.channels):
             # current has to be a list (or something mutable at least), because
             # it have to be updated on multiple labes

--- a/python/tests/test_frames.py
+++ b/python/tests/test_frames.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import dlisio
 
 from . import DWL206
@@ -16,7 +18,7 @@ def test_frame_getitem(DWL206):
     assert curves['TDEP'][0] == 852606.0
     assert curves[0]['TDEP'] == 852606.0
 
-def test_duplicated_mnemonics_gets_unique_labels():
+def makeframe():
     time0 = dlisio.plumbing.Channel()
     time0.name = 'TIME'
     time0.origin = 0
@@ -41,5 +43,26 @@ def test_duplicated_mnemonics_gets_unique_labels():
     frame = dlisio.plumbing.Frame()
     frame.channels = [time0, tdep, time1]
 
+    return frame
+
+def test_duplicated_mnemonics_gets_unique_labels():
+    frame = makeframe()
     assert 'fDDD' == frame.fmtstr()
-    assert ('TIME:0:0', 'TDEP', 'TIME:1:0') == frame.dtype.names
+    assert ('TIME.0.0', 'TDEP', 'TIME.1.0') == frame.dtype.names
+
+def test_duplicated_mnemonics_dtype_supports_buffer_protocol():
+    # Getting a buffer from a numpy array adds a :name: field after the label
+    # name, and forbids the presence of :. Unfortunately, the full visible
+    # (non-whitespace) ascii set is legal for the RP66 IDENT type, so in theory
+    # it's possible that a similar mnemonic can be legally present.
+    #
+    # In practice, this is unlikely to be a problem. By default, dlisio uses
+    # the full stop (.) as a separator, but for particularly nasty files this
+    # would collide with a different channel mnemonic in the same frame. A
+    # possible fix could be to use a blank character for mnemonic-origin-copy
+    # separation, or lowercase letters (which are not supposed to be a part of
+    # the IDENT type, but dlisio imposes no such restriction)
+    #
+    # https://github.com/equinor/dlisio/pull/97
+    frame = makeframe()
+    _ = memoryview(np.zeros(1, dtype = frame.dtype))

--- a/python/tests/test_frames.py
+++ b/python/tests/test_frames.py
@@ -66,3 +66,34 @@ def test_duplicated_mnemonics_dtype_supports_buffer_protocol():
     # https://github.com/equinor/dlisio/pull/97
     frame = makeframe()
     _ = memoryview(np.zeros(1, dtype = frame.dtype))
+
+def test_instance_dtype_fmt():
+    frame = makeframe()
+    frame.dtype_fmt = 'x-{:s} {:d}~{:d}'
+
+    # fmtstr is unchanged
+    assert 'fDDD' == frame.fmtstr()
+    assert ('x-TIME 0~0', 'TDEP', 'x-TIME 1~0') == frame.dtype.names
+
+def test_instance_dtype_fmt():
+    frame = makeframe()
+    frame.dtype_fmt = 'x-{:s} {:d}~{:d}'
+
+    # fmtstr is unchanged
+    assert 'fDDD' == frame.fmtstr()
+    assert ('x-TIME 0~0', 'TDEP', 'x-TIME 1~0') == frame.dtype.names
+
+def test_class_dtype_fmt():
+    original = dlisio.plumbing.Frame.dtype_format
+
+    try:
+        # change dtype before the object itself is constructed, so it
+        dlisio.plumbing.Frame.dtype_format = 'x-{:s} {:d}~{:d}'
+        frame = makeframe()
+        assert 'fDDD' == frame.fmtstr()
+        assert ('x-TIME 0~0', 'TDEP', 'x-TIME 1~0') == frame.dtype.names
+
+    finally:
+        # even if the test fails, make sure the format string is reset to its
+        # default, to not interfere with other tests
+        dlisio.plumbing.Frame.dtype_format = original


### PR DESCRIPTION
As reported in [1], reading raw buffers of numpy arrays fails when :
appears in field names in the structured arrays.

[1] https://github.com/equinor/dlisio/pull/97