### PR TITLE
Permit reprcode change to the same reprcode

### DIFF
--- a/lib/src/parse.cpp
+++ b/lib/src/parse.cpp
@@ -920,9 +920,9 @@ object_vector parse_objects( const object_template& tmpl,
                  * certain codes (ident -> ascii), but is no need for now
                  */
 
-                if (flags.reprc) {
-                    const auto msg = "count ({}) and representation code "
-                            "({}) changed, but value is not explicitly set";
+                if (flags.reprc && attr.reprc != template_attr.reprc) {
+                    const auto msg = "count ({}) isn't 0 and representation "
+                        "code ({}) changed, but value is not explicitly set";
                     const auto code = static_cast< int >(attr.reprc);
                     throw std::runtime_error(fmt::format(msg, count, code));
                 }

--- a/python/data/parse/objattr/repeat-default-novalue.dlis.part
+++ b/python/data/parse/objattr/repeat-default-novalue.dlis.part
@@ -1,0 +1,1 @@
+.default attr units

--- a/python/tests/test_parse.py
+++ b/python/tests/test_parse.py
@@ -275,6 +275,23 @@ def test_different_repcode_no_value(tmpdir, merge):
     assert "value is not explicitly set" in str(excinfo.value)
 
 
+def test_same_as_default_no_value(tmpdir, merge):
+    path = os.path.join(str(tmpdir), 'same-as-default-but-no-value.dlis')
+    content = [
+        'data/parse/start.dlis.part',
+        'data/parse/template/default.dlis.part',
+        'data/parse/object/object.dlis.part',
+        'data/parse/objattr/repeat-default-novalue.dlis.part'
+    ]
+    merge(path, content)
+
+    with dlisio.load(path) as f:
+        key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
+        obj = f.objects[key]
+        attr = obj.attic['DEFAULT_ATTRIBUTE']
+        assert attr == [-0.75, 10.0]
+
+
 @pytest.mark.future_test_attributes
 def test_novalue_less_count(tmpdir, merge):
     path = os.path.join(str(tmpdir), 'novalue-less-count.dlis')


### PR DESCRIPTION
Recently a check has been introduced that reported an error in case
someone changes default reprcode from the template in the object, but
doesn't change the value itself (leaving it to be default).
But it hasn't accounted for the case where reprcode wasn't actually
changed, but repeated to be the same as in template. We don't want any
error in this case.
Fixed and added test.