### PR TITLE
Register operators != and == for core.objref

### DIFF
--- a/python/dlisio/ext/core.cpp
+++ b/python/dlisio/ext/core.cpp
@@ -451,6 +451,8 @@ PYBIND11_MODULE(core, m) {
     py::class_< dl::objref >( m, "objref" )
         .def_readonly( "type", &dl::objref::type )
         .def_readonly( "name", &dl::objref::name )
+        .def( "__eq__",        &dl::objref::operator == )
+        .def( "__ne__",        &dl::objref::operator != )
         .def_property_readonly("fingerprint", &dl::objref::fingerprint)
         .def( "__repr__", []( const dl::objref& o ) {
             return "dlisio.core.objref(fingerprint={})"_s


### PR DESCRIPTION
dl::objref operators != and == was not registered in the python
extension. dlis.load() uses these operators when duplicated fingerprints
are found, as a result the entire load procedure failed.