### PR TITLE
Fix travis build

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -8,7 +8,9 @@ function run_tests {
 function pre_build {
     if [ -d build-centos5 ]; then return; fi
 
-    python -m pip install cmake pybind11 scikit-build
+    python -m pip install scikit-build
+    python -m pip install cmake==3.13.3
+    python -m pip install pybind11
 
     mkdir build-centos5
     pushd build-centos5


### PR DESCRIPTION
Travis build failed.
Leading theory - new cmake depends on scikit-build.
Hence trying to install it before installing cmake.