### PR TITLE
ci: Fix build of linux wheel requiring cmake<3.14

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -8,7 +8,7 @@ function run_tests {
 function pre_build {
     if [ -d build-centos5 ]; then return; fi
 
-    python -m pip install cmake pybind11 scikit-build
+    python -m pip install "cmake<3.14" pybind11 scikit-build
 
     mkdir build-centos5
     pushd build-centos5


### PR DESCRIPTION
Since starting with CMake 3.14, only manylinux2010 compatible wheels are
available, requiring any version of cmake ends building cmake from source
when installed from a manylinux1 system.

See https://github.com/scikit-build/cmake-python-distributions/issues/76