### PR TITLE
Partision physical-file -> logical-files in load()

### DIFF
--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -4,12 +4,12 @@ import dlisio
 
 @pytest.fixture(scope="module", name="DWL206")
 def DWL206():
-    with dlisio.load('data/206_05a-_3_DWL_DWL_WIRE_258276498.DLIS') as f:
+    with dlisio.load('data/206_05a-_3_DWL_DWL_WIRE_258276498.DLIS') as (f,):
         yield f
 
 @pytest.fixture(scope="module", name="only_channels")
 def only_channels():
-    with dlisio.load('data/only-channels.dlis') as f:
+    with dlisio.load('data/only-channels.dlis') as (f,):
         yield f
 
 @pytest.fixture(scope="module")

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -427,17 +427,17 @@ def test_dtype(DWL206):
                                ('DEPT_SL', np.float32)])
 
 def test_load_pre_sul_garbage(only_channels):
-    with dlisio.load('data/pre-sul-garbage.dlis') as f:
+    with dlisio.load('data/pre-sul-garbage.dlis') as (f,):
         assert f.storage_label() == f.storage_label()
         assert f.sul_offset == 12
 
 def test_load_pre_vrl_garbage(only_channels):
-    with dlisio.load('data/pre-sul-pre-vrl-garbage.dlis') as f:
+    with dlisio.load('data/pre-sul-pre-vrl-garbage.dlis') as (f,):
         assert f.storage_label() == f.storage_label()
         assert f.sul_offset == 12
 
 def test_load_file_with_broken_utf8():
-    with dlisio.load('data/broken-degree-symbol.dlis') as f:
+    with dlisio.load('data/broken-degree-symbol.dlis') as (f, *tail):
         pass
 
 def test_padbytes_as_large_as_record():

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -1,0 +1,128 @@
+import pytest
+
+import dlisio
+
+from . import merge_files
+
+@pytest.fixture(scope="module")
+def fpath(tmpdir_factory, merge_files):
+    path = str(tmpdir_factory.mktemp('semantic').join('manylogfiles.dlis'))
+    content = [
+        'data/semantic/envelope.dlis.part',
+        # First logical file, does not have FILE-HEADER
+        'data/semantic/origin.dlis.part',
+        'data/semantic/channel.dlis.part',
+        'data/semantic/frame.dlis.part',
+        # Second logical file
+        'data/semantic/file-header.dlis.part',
+        'data/semantic/origin2.dlis.part',
+        'data/semantic/channel-reprcode.dlis.part',
+        'data/semantic/frame-reprcode.dlis.part',
+        'data/semantic/fdata-reprcode.dlis.part',
+        'data/semantic/frame.dlis.part',
+        'data/semantic/fdata-reprcode.dlis.part',
+        # Third logical file, only has a FILE-HEADER
+        'data/semantic/file-header2.dlis.part',
+    ]
+    merge_files(path, content)
+    return path
+
+def test_context_manager(fpath):
+    f, *_ = dlisio.load(fpath)
+    _ = f.fileheader
+    f.close()
+
+    files = dlisio.load(fpath)
+    for f in files:
+        _ = f.fileheader
+        f.close()
+
+    f, *files = dlisio.load(fpath)
+    _ = f.fileheader
+    for g in files:
+        _ = g.fileheader
+        g.close()
+
+def test_context_manager_with(fpath):
+    with dlisio.load(fpath) as (f, *_):
+        _ = f.fileheader
+
+    with dlisio.load(fpath) as files:
+        for f in files:
+            _ = f.fileheader
+
+    with dlisio.load(fpath) as (f, *files):
+        _ = f.fileheader
+        for g in files:
+            _ = g.fileheader
+
+def test_partitioning(fpath):
+    with dlisio.load(fpath) as (f1, f2, f3, *tail):
+        assert len(tail) == 0
+
+        assert len(f1.objects) == 8
+        assert len(f2.objects) == 32
+        assert len(f3.objects) == 1
+
+        key = dlisio.core.fingerprint('FRAME', 'FRAME-REPRCODE', 10, 0)
+
+        assert f1.explicit_indices == [0, 1, 2]
+        assert not f1.fdata_index
+
+        assert f2.explicit_indices == [0, 1, 2, 3, 5]
+        assert f2.fdata_index[key] == [4, 6]
+
+        assert f3.explicit_indices == [0]
+        assert not f3.fdata_index
+
+def test_objects(fpath):
+    with dlisio.load(fpath) as (f1, f2, f3):
+        key = dlisio.core.fingerprint('FILE-HEADER', 'N', 10, 0)
+        fh2 = f2.objects[key]
+        key = dlisio.core.fingerprint('FILE-HEADER', 'N', 11, 0)
+        fh3 = f3.objects[key]
+
+        assert len(f1.fileheader) == 0
+        assert len(f1.origin)     == 2
+        assert len(f1.channels)   == 4
+        assert len(f1.frames)     == 2
+
+        assert fh2.sequencenr == '8'
+        assert fh2.id         == 'some logical file'
+        assert fh2 not in f3.fileheader
+
+        assert len(f2.origin)   == 1
+        assert len(f2.channels) == 27
+        assert len(f2.frames)   == 3
+
+        assert fh3.sequencenr == '10'
+        assert fh3.id         == 'Yet another logical file'
+        assert fh3 not in f2.fileheader
+
+def test_link(fpath):
+    with dlisio.load(fpath) as (f1, f2, _):
+        key = dlisio.core.fingerprint('FRAME', 'FRAME1', 10, 0)
+        frame1 = f1.objects[key]
+        frame2 = f2.objects[key]
+
+        key = dlisio.core.fingerprint('CHANNEL', 'CHANN1', 10, 0)
+        channel = f1.objects[key]
+
+        # The same frame is present in two different logical files. The
+        # channels in frame.channel are only present in the first
+        # logical file. Thus links are not available in the second file.
+        assert channel in frame1.channels
+        assert channel not in frame2.channels
+
+def test_curves(fpath):
+    with dlisio.load(fpath) as (_, f2, _):
+        key = dlisio.core.fingerprint('FRAME', 'FRAME-REPRCODE', 10, 0)
+        curves = f2.curves(key)
+
+        # Read the first value of the first frame of channel CH01
+        assert curves['CH01'][0][0] == 153.0
+        assert curves[0]['CH01'][0] == 153.0
+
+        # Read the first value of the second frame of channel CH01
+        assert curves['CH01'][1][0] == 153.0
+        assert curves[1]['CH01'][0] == 153.0

--- a/python/tests/test_parse.py
+++ b/python/tests/test_parse.py
@@ -22,7 +22,7 @@ def test_invariant_attribute(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['INVARIANT_ATTRIBUTE']
@@ -43,7 +43,7 @@ def test_invariant_attribute_in_object(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['DEFAULT_ATTRIBUTE']
@@ -61,7 +61,7 @@ def test_default_attribute(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['DEFAULT_ATTRIBUTE']
@@ -81,7 +81,7 @@ def test_default_attribute_cut(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         assert obj.attic['INVARIANT_ATTRIBUTE']
@@ -99,7 +99,7 @@ def test_attribute_absent(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         assert obj.attic['INVARIANT_ATTRIBUTE']
@@ -118,7 +118,7 @@ def test_absent_attribute_in_template(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         assert obj.attic['DEFAULT_ATTRIBUTE']
@@ -135,7 +135,7 @@ def test_global_default_attribute(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['GLOBAL_DEFAULT_ATTRIBUTE']
@@ -156,7 +156,7 @@ def test_all_attribute_bits(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['DEFAULT_ATTRIBUTE']
@@ -177,7 +177,7 @@ def test_label_bit_set_in_attribute(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         assert obj.attic['DEFAULT_ATTRIBUTE']
@@ -194,7 +194,7 @@ def test_label_bit_not_set_in_template(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['NEW_ATTRIBUTE']
@@ -213,7 +213,7 @@ def test_count0_novalue(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['DEFAULT_ATTRIBUTE']
@@ -232,7 +232,7 @@ def test_count0_value_bit(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['DEFAULT_ATTRIBUTE']
@@ -251,7 +251,7 @@ def test_count0_different_repcode(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['DEFAULT_ATTRIBUTE']
@@ -285,7 +285,7 @@ def test_same_as_default_no_value(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['DEFAULT_ATTRIBUTE']
@@ -303,7 +303,7 @@ def test_novalue_less_count(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic['DEFAULT_ATTRIBUTE']
@@ -374,7 +374,7 @@ def test_repcode(tmpdir, merge, filename_p, attr_n, attr_reprc, attr_v):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         attr = obj.attic[attr_n]
@@ -422,7 +422,7 @@ def test_set_type_not_set(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         assert obj.attic['DEFAULT_ATTRIBUTE']
@@ -438,7 +438,7 @@ def test_no_object_name_bit(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f, *tail):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         assert obj.attic['DEFAULT_ATTRIBUTE']
@@ -466,7 +466,7 @@ def test_no_template(tmpdir, merge):
     ]
     merge(path, content)
 
-    with dlisio.load(path) as f:
+    with dlisio.load(path) as (f,):
         key = dlisio.core.fingerprint('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
         obj = f.objects[key]
         assert len(obj.attic) == 0

--- a/python/tests/test_semantics.py
+++ b/python/tests/test_semantics.py
@@ -40,7 +40,7 @@ def fpath(tmpdir_factory, merge_files):
 
 @pytest.fixture(scope="module")
 def f(tmpdir_factory, fpath):
-    with dlisio.load(fpath) as f:
+    with dlisio.load(fpath) as (f, *tail):
         yield f
 
 def test_file_header(f):
@@ -392,7 +392,7 @@ def test_unexpected_attributes(f):
                                                   (10, 0, "OBJ1"))]
 
 def test_dynamic_class(fpath):
-    with dlisio.load(fpath) as f:
+    with dlisio.load(fpath) as (f, _):
         class ActuallyKnown(dlisio.plumbing.basicobject.BasicObject):
             attributes = {
                 "SOME_LIST"   : dlisio.plumbing.valuetypes.vector('list'),
@@ -422,7 +422,7 @@ def test_dynamic_class(fpath):
         assert unknown.status == True
 
 def test_dynamic_instance_attribute(fpath):
-    with dlisio.load(fpath) as f:
+    with dlisio.load(fpath) as (f, _):
         key = dlisio.core.fingerprint(
                           'CALIBRATION-COEFFICIENT', 'COEFF_BAD', 10, 0)
         c = f.objects[key]
@@ -442,7 +442,7 @@ def test_dynamic_instance_attribute(fpath):
             c.attributes['myparams']
 
 def test_dynamic_class_attribute(fpath):
-    with dlisio.load(fpath) as f:
+    with dlisio.load(fpath) as (f, _):
         # update attribute for the class
         dlisio.plumbing.coefficient.Coefficient.attributes['MY_PARAM'] = (
                         dlisio.plumbing.valuetypes.vector('myparams'))
@@ -460,7 +460,7 @@ def test_dynamic_class_attribute(fpath):
         del c.__class__.attributes['MY_PARAM']
 
 def test_dynamic_linkage(fpath):
-    with dlisio.load(fpath) as f:
+    with dlisio.load(fpath) as (f, _):
         key = dlisio.core.fingerprint(
                           'CALIBRATION-COEFFICIENT', 'COEFF_BAD', 10, 0)
         c = f.objects[key]


### PR DESCRIPTION
The dlis standard have a concept of logical files. A logical file is a
group of related logical records, i.e. curves and metadata and is
independent from any other logical file. Each physical file (.dlis) can
contain 1 to n logical files.

load() now returns a tuple-like with one file-handle pr logical file
in the physical file.