### PR TITLE
Add .describe() method's to all object-types

### DIFF
--- a/python/dlisio/__init__.py
+++ b/python/dlisio/__init__.py
@@ -360,6 +360,61 @@ class dlis(object):
         return self.indexedobjects['PARAMETER'].values()
 
     @property
+    def process(self):
+        """ Read all Process objects
+
+        Returns
+        -------
+
+        processes : dict_values
+        """
+        return self.indexedobjects['PROCESS'].values()
+
+    @property
+    def group(self):
+        """ Read all Group objects
+
+        Returns
+        -------
+
+        groups : dict_values
+        """
+        return self.indexedobjects['GROUP'].values()
+
+    @property
+    def wellref(self):
+        """ Read all Wellref objects
+
+        Returns
+        -------
+
+        wellrefs : dict_values
+        """
+        return self.indexedobjects['WELL-REFERENCE'].values()
+
+    @property
+    def splice(self):
+        """ Read all Splice objects
+
+        Returns
+        -------
+
+        splice : dict_values
+        """
+        return self.indexedobjects['SPLICE'].values()
+
+    @property
+    def path(self):
+        """ Read all Path objects
+
+        Returns
+        -------
+
+        path : dict_values
+        """
+        return self.indexedobjects['PATH'].values()
+
+    @property
     def equipments(self):
         """ Read all Equipment objects
 

--- a/python/dlisio/plumbing/axis.py
+++ b/python/dlisio/plumbing/axis.py
@@ -1,5 +1,8 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector
+from .utils import describe_dict
+
+from collections import OrderedDict
 
 
 class Axis(BasicObject):
@@ -38,3 +41,11 @@ class Axis(BasicObject):
         #: Constant, signed spacing along the axis between successive
         #: coordinates
         self.spacing     = None
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Description'] = self.axis_id
+        d['Spacing']     = self.spacing
+        d['Coordinates'] = self.coordinates
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/calibration.py
+++ b/python/dlisio/plumbing/calibration.py
@@ -1,6 +1,9 @@
 from .basicobject import BasicObject
 from .valuetypes import vector, scalar
 from .linkage import obname
+from .utils import describe_dict, replist
+
+from collections import OrderedDict
 
 class Calibration(BasicObject):
     """
@@ -58,3 +61,14 @@ class Calibration(BasicObject):
         #: Parameters containing numerical and textual information assosiated
         #: with the calibration process.
         self.parameters        = []
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Computational method']  = self.method
+        d['Calibrated channels']   = replist(self.calibrated  , 'name')
+        d['Uncalibrated channels'] = replist(self.uncalibrated, 'name')
+        d['Coefficients']          = replist(self.coefficients, 'name')
+        d['Measurements']          = replist(self.measurements, 'name')
+        d['Parameters']            = replist(self.parameters  , 'name')
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/channel.py
+++ b/python/dlisio/plumbing/channel.py
@@ -3,8 +3,11 @@ from ..reprc import dtype, fmt
 from ..dlisutils import curves
 from .valuetypes import scalar, vector
 from .linkage import obname, objref
+from .utils import *
 
 import numpy as np
+from collections import OrderedDict
+
 
 class Channel(BasicObject):
     """
@@ -167,3 +170,16 @@ class Channel(BasicObject):
         frame = self.frame
         pre_fmt, fmt, post_fmt = frame.fmtstrchannel(self)
         return curves(frame.file, frame, self.dtype, pre_fmt, fmt, post_fmt)
+
+    def describe_attr(self, buf, width, indent, exclude):
+        describe_description(buf, self.long_name, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Physical unit of sample']   = self.units
+        d['Sample dimensions']         = self.dimension
+        d['Axis']                      = self.axis
+        d['Maximum sample dimensions'] = self.element_limit
+        d['Property indicators']       = self.properties
+        d['Source']                    = self.source
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/coefficient.py
+++ b/python/dlisio/plumbing/coefficient.py
@@ -1,5 +1,8 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector
+from .utils import *
+
+from collections import OrderedDict
 
 class Coefficient(BasicObject):
     """
@@ -46,3 +49,27 @@ class Coefficient(BasicObject):
         #: Maximum value that a sample can fall below the reference and still
         #: be "within tolerance"
         self.minus_tolerance = []
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Coefficient type']   = self.label
+        d['Number of value(s)'] = len(self.coefficients)
+
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Reference value(s)'] =  'REFERENCES'
+        d['Minus Tolerance(s)'] =  'PLUS-TOLERANCES'
+        d['Plus Tolerance(s)']  =  'MINUS-TOLERANCES'
+
+        describe_sampled_attrs(
+                buf,
+                self.attic,
+                [1],
+                'COEFFICIENTS',
+                d,
+                width,
+                indent,
+                exclude,
+                single=False
+        )

--- a/python/dlisio/plumbing/computation.py
+++ b/python/dlisio/plumbing/computation.py
@@ -125,3 +125,25 @@ class Computation(BasicObject):
 
         shape = validshape(values, self.dimension, samplecount=len(self.zones))
         return sampling(values, shape)
+
+    def describe_attr(self, buf, width, indent, exclude):
+        describe_description(buf, self.long_name, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Sample dimensions']   = self.dimension
+        d['Axis labels']         = self.axis
+        d['Zones']               = self.zones
+        d['Property indicators'] = self.properties
+        d['Source object']       = self.source
+        describe_dict(buf, d, width, indent, exclude)
+
+        describe_sampled_attrs(
+                buf,
+                self.attic,
+                self.dimension,
+                'VALUES',
+                None,
+                width,
+                indent,
+                exclude
+        )

--- a/python/dlisio/plumbing/equipment.py
+++ b/python/dlisio/plumbing/equipment.py
@@ -1,5 +1,8 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar, boolean
+from .utils import describe_dict
+
+from collections import OrderedDict
 
 
 class Equipment(BasicObject):
@@ -94,3 +97,34 @@ class Equipment(BasicObject):
 
         #: Angular drift
         self.angular_drift  = None
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Trademark name']     = self.trademark_name
+        d['Generic type']       = self.generic_type
+        d['Operational status'] = self.status
+        d['Serial number']      = self.serial_number
+        d['Location']           = self.location
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Height, Length']      = [self.height, self.length]
+        d['Diameter (min, max)'] = [self.diameter_min, self.diameter_max]
+        d['Volume']              = self.volume
+        d['Weight']              = self.weight
+
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Minimum borehole size'] = self.hole_size
+        d['Max pressure']          = self.pressure
+        d['Max temperature']       = self.temperature
+
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Vertical depth'] = self.vertical_depth
+        d['Radial drift ']  = self.radial_drift
+        d['Angular drift']  = self.angular_drift
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/fileheader.py
+++ b/python/dlisio/plumbing/fileheader.py
@@ -1,5 +1,8 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar
+from .utils import describe_dict
+
+from collections import OrderedDict
 
 class Fileheader(BasicObject):
     """
@@ -61,3 +64,10 @@ class Fileheader(BasicObject):
 
         #:Descriptive identification of the logical file
         self.id         = None
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Description'] = self.id
+        d['Position in storage set'] = self.sequencenr
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/frame.py
+++ b/python/dlisio/plumbing/frame.py
@@ -1,8 +1,8 @@
 from .basicobject import BasicObject
-from ..reprc import fmt
 from ..dlisutils import curves
 from .valuetypes import scalar, vector, boolean
 from .linkage import obname
+from .utils import *
 
 import numpy as np
 import logging
@@ -301,3 +301,28 @@ class Frame(BasicObject):
             except AttributeError:
                 #happens if ch has been parsed as other type
                 pass
+
+    def describe_attr(self, buf, width=80, indent='', exclude=''):
+        if len(self.channels) > 0:
+            if self.index_type is not None:
+                d = OrderedDict()
+                d['Description']      =  self.description
+                d['Indexed by']       =  self.index_type
+                d['Interval']         =  str([self.index_min, self.index_max])
+                d['Direction']        =  self.direction
+                d['Constant spacing'] =  self.spacing
+                d['Index channel']    =  self.channels[0]
+
+                describe_header(buf, 'Channel indexing', width, indent, lvl=2)
+                describe_dict(buf, d, width, indent, exclude)
+
+            else:
+                index  = 'There is no index channel, channels are indexed '
+                index += 'by samplenumber, i.e [1,2,3,..,n]'
+                describe_text(buf, index, indent=indent, width=width)
+
+            describe_header(buf, 'Channels', width, indent, lvl=2)
+            channels = replist(self.channels, 'name')
+            describe_array(buf, channels, width, indent)
+        else:
+            describe_text(buf, 'Frame has no channels', width, indent)

--- a/python/dlisio/plumbing/group.py
+++ b/python/dlisio/plumbing/group.py
@@ -19,7 +19,7 @@ class Group(BasicObject):
         Specifies the type of object that is referenced in the object list
         attribute.
 
-    object_list :
+    object_list
         References to arbitrary objects.
 
     group_list : list of Group

--- a/python/dlisio/plumbing/group.py
+++ b/python/dlisio/plumbing/group.py
@@ -2,7 +2,9 @@ from .. import core
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector
 from .linkage import obname, objref
+from .utils import describe_dict
 
+from collections import OrderedDict
 from copy import deepcopy
 
 class Group(BasicObject):
@@ -72,3 +74,11 @@ class Group(BasicObject):
             self.linkage['objects'] = obname(self.objecttype)
 
         super().link(objects)
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Description']  = self.description
+        d['Object list']  = self.objects
+        d['Group list']   = self.groups
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/longname.py
+++ b/python/dlisio/plumbing/longname.py
@@ -1,5 +1,8 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector
+from .utils import describe_dict
+
+from collections import OrderedDict
 
 
 class Longname(BasicObject):
@@ -89,3 +92,22 @@ class Longname(BasicObject):
         #: records or objects of the Producer’s internal or corporate database
         self.private_symbol  = None
 
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['General modifier']   =  self.modifier
+        d['Quantity']           =  self.quantity
+        d['Quantity modifier']  =  self.quantity_mod
+        d['Altered form']       =  self.altered_form
+        d['Entity']             =  self.entity
+        d['Entity modifier']    =  self.entity_mod
+        d['Entity number']      =  self.entity_nr
+        d['Entity part']        =  self.entity_part
+        d['Entity part number'] =  self.entity_part_nr
+        d['Generic source']     =  self.generic_source
+        d['Source part']        =  self.source_part
+        d['Source part number'] =  self.source_part_nr
+        d['Conditions']         =  self.conditions
+        d['Standard symbol']    =  self.standard_symbol
+        d['Private symbol']     =  self.private_symbol
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/measurement.py
+++ b/python/dlisio/plumbing/measurement.py
@@ -1,8 +1,9 @@
 from .basicobject import BasicObject
-from .valuetypes import scalar, vector, reverse
+from .valuetypes import scalar, vector, reverse, skip
 from .linkage import objref, obname
-from .utils import sampling
+from .utils import *
 
+import logging
 import numpy as np
 
 
@@ -25,15 +26,21 @@ class Measurement(BasicObject):
     5.8.7.1 - Static and Frame Data, CALIBRATION-MEASUREMENT objects.
     """
     attributes = {
-          'PHASE'             : scalar('phase'),
-          'MEASUREMENT-SOURCE': scalar('source'),
-          'TYPE'              : scalar('mtype'),
-          'DIMENSION'         : reverse('dimension'),
-          'AXIS'              : reverse('axis'),
-          'SAMPLE-COUNT'      : scalar('samplecount'),
-          'BEGIN-TIME'        : scalar('begin_time'),
-          'DURATION'          : scalar('duration'),
-          'STANDARD'          : vector('standard'),
+        'PHASE'             : scalar('phase'),
+        'MEASUREMENT-SOURCE': scalar('source'),
+        'TYPE'              : scalar('mtype'),
+        'DIMENSION'         : reverse('dimension'),
+        'AXIS'              : reverse('axis'),
+        'MEASUREMENT'       : skip(),
+        'SAMPLE-COUNT'      : scalar('samplecount'),
+        'MAXIMUM-DEVIATION' : skip(),
+        'STANDARD-DEVIATION': skip(),
+        'BEGIN-TIME'        : scalar('begin_time'),
+        'DURATION'          : scalar('duration'),
+        'REFERENCE'         : skip(),
+        'STANDARD'          : vector('standard'),
+        'PLUS-TOLERANCE'    : skip(),
+        'MINUS-TOLERANCE'   : skip(),
     }
 
     linkage = {
@@ -80,14 +87,13 @@ class Measurement(BasicObject):
         may be either a scalar or ndarray
         """
         try:
-            data = self.attic['MEASUREMENT']
+            samples = self.attic['MEASUREMENT']
         except KeyError:
             return np.empty(0)
 
-        try:
-            return sampling(data, self.dimension)
-        except ValueError:
-            return np.array(data)
+        shape = validshape(samples, self.dimension)
+        return sampling(samples, shape)
+
 
     @property
     def max_deviation(self):
@@ -101,14 +107,12 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            data = self.attic['MAXIMUM-DEVIATION']
+            dev = self.attic['MAXIMUM-DEVIATION']
         except KeyError:
             return np.empty(0)
 
-        try:
-            return sampling(data, self.dimension)
-        except ValueError:
-            return np.array(data)
+        shape = validshape(dev, self.dimension)
+        return sampling(dev, shape, single=True)
 
     @property
     def std_deviation(self):
@@ -122,14 +126,12 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            data = self.attic['STANDARD-DEVIATION']
+            dev = self.attic['STANDARD-DEVIATION']
         except KeyError:
             return np.empty(0)
 
-        try:
-            return sampling(data, self.dimension)
-        except ValueError:
-            return np.array(data)
+        shape = validshape(dev, self.dimension)
+        return sampling(dev, shape, single=True)
 
     @property
     def reference(self):
@@ -139,14 +141,12 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            data = self.attic['REFERENCE']
+            ref = self.attic['REFERENCE']
         except KeyError:
             return np.empty(0)
 
-        try:
-            return sampling(data, self.dimension)
-        except ValueError:
-            return np.array(data)
+        shape = validshape(ref, self.dimension)
+        return sampling(ref, shape, single=True)
 
     @property
     def plus_tolerance(self):
@@ -159,14 +159,12 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            data = self.attic['PLUS-TOLERANCE']
+            tolerance = self.attic['PLUS-TOLERANCE']
         except KeyError:
             return np.empty(0)
 
-        try:
-            return sampling(data, self.dimension)
-        except ValueError:
-            return np.array(data)
+        shape = validshape(tolerance, self.dimension)
+        return sampling(tolerance, shape, single=True)
 
     @property
     def minus_tolerance(self):
@@ -179,11 +177,9 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            data = self.attic['MINUS-TOLERANCE']
+            tolerance   = self.attic['MINUS-TOLERANCE']
         except KeyError:
             return np.empty(0)
 
-        try:
-            return sampling(data, self.dimension)
-        except ValueError:
-            return np.array(data)
+        shape = validshape(tolerance, self.dimension)
+        return sampling(tolerance, shape, single=True)

--- a/python/dlisio/plumbing/measurement.py
+++ b/python/dlisio/plumbing/measurement.py
@@ -3,6 +3,7 @@ from .valuetypes import scalar, vector, reverse, skip
 from .linkage import objref, obname
 from .utils import *
 
+from collections import OrderedDict
 import logging
 import numpy as np
 
@@ -183,3 +184,48 @@ class Measurement(BasicObject):
 
         shape = validshape(tolerance, self.dimension)
         return sampling(tolerance, shape, single=True)
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Type of measurement']       = self.mtype
+        d['Calibration standard']      = self.standard
+        d['Phase in job sequence']     = self.phase
+        d['Start time of acquisition'] = self.begin_time
+        d['Duration time']             = self.duration
+        d['Data source']               = self.source
+
+        describe_header(buf, 'Metadata', width, indent, lvl=2)
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Dimensions']       = self.dimension
+        d['Axis labels']      = self.axis
+        try:
+            samplecount = len(self.samples)
+        except ValueError:
+            samplecount = 0
+        d['Number of values'] = samplecount
+        samples = 'Samples used to compute std/max-dev'
+        d[samples] = self.samplecount
+
+        if exclude['empty']: d = remove_empties(d)
+        if d: describe_header(buf, 'Samples', width, indent, lvl=2)
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Reference']       = 'REFERENCE'
+        d['Minus Tolerance'] = 'MINUS-TOLERANCE'
+        d['Plus Tolerance']  = 'PLUS-TOLERANCE'
+        d['Std deviation']   = 'STANDARD-DEVIATION'
+        d['Max deviation']   = 'MAXIMUM-DEVIATION'
+
+        describe_sampled_attrs(
+                buf,
+                self.attic,
+                self.dimension,
+                'MEASUREMENT',
+                d,
+                width,
+                indent,
+                exclude
+        )

--- a/python/dlisio/plumbing/origin.py
+++ b/python/dlisio/plumbing/origin.py
@@ -1,5 +1,8 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector
+from .utils import describe_dict
+
+from collections import OrderedDict
 
 class Origin(BasicObject):
     """ Describes the creation of the logical file.
@@ -121,3 +124,34 @@ class Origin(BasicObject):
 
         #: The version of the namespace.
         self.namespace_version = None
+
+    def describe_attr(self, buf, width, indent, exclude):
+        fileset  = '{} / {}'.format(self.file_set_name, self.file_set_nr)
+        fileinfo = '{} / {}'.format(self.file_nr, self.file_type)
+        d = OrderedDict()
+        d['Logical file ID']          = self.file_id
+        d['File set name and number'] = fileset
+        d['File number and type']     = fileinfo
+
+        describe_dict(buf, d, width, indent, exclude)
+
+        well     = '{} / {}'.format(self.well_id, self.well_name)
+        producer = '{} / {}'.format(self.producer_code, self.producer_name)
+        d = OrderedDict()
+        d['Field']                   = self.field_name
+        d['Well (id/name)']          = well
+        d['Produced by (code/name)'] = producer
+        d['Produced for']            = self.company
+        d['Order number']            = self.order_nr
+        d['Run number']              = self.run_nr
+        d['Descent number']          = self.descent_nr
+        d['Created']                 = self.creation_time
+
+        describe_dict(buf, d, width, indent, exclude)
+
+        prog = '{}, (version: {})'.format(self.product, self.version)
+        d = OrderedDict()
+        d['Created by'] = prog
+        d['Other programs/services'] = self.programs
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/parameter.py
+++ b/python/dlisio/plumbing/parameter.py
@@ -5,6 +5,8 @@ from .utils import *
 
 import logging
 import numpy as np
+from collections import OrderedDict
+
 
 class Parameter(BasicObject):
     """Parameter
@@ -111,3 +113,24 @@ class Parameter(BasicObject):
 
         shape = validshape(values, self.dimension, samplecount=len(self.zones))
         return sampling(values, shape)
+
+    def describe_attr(self, buf, width, indent, exclude):
+        describe_description(buf, self.long_name, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Sample dimensions'] = self.dimension
+        d['Axis labels']       = self.axis
+        d['Zones']             = self.zones
+
+        describe_dict(buf, d, width, indent, exclude)
+
+        describe_sampled_attrs(
+                buf,
+                self.attic,
+                self.dimension,
+                'VALUES',
+                None,
+                width,
+                indent,
+                exclude
+        )

--- a/python/dlisio/plumbing/parameter.py
+++ b/python/dlisio/plumbing/parameter.py
@@ -1,8 +1,9 @@
 from .basicobject import BasicObject
-from .valuetypes import scalar, vector, reverse
+from .valuetypes import scalar, vector, reverse, skip
 from .linkage import obname
-from .utils import sampling, zonify
+from .utils import *
 
+import logging
 import numpy as np
 
 class Parameter(BasicObject):
@@ -11,8 +12,11 @@ class Parameter(BasicObject):
     A parameter object describes a parameter used in the acquisition and
     processing of data.  The parameter value(s) may be scalars or an array. In
     the later case, the structure of the array is defined in the dimension
-    attribute. The zone attribute specifies which zone(s) the parameter is
-    defined. If there are no zone(s) the parameter is defined everywhere.
+    attribute. The zones attribute specifies which zones the parameter is
+    defined. If there are no zones the parameter is defined everywhere.
+
+    The axis attribute, if present, defines axis labels for multidimensional
+    value(s).
 
     See also
     --------
@@ -32,6 +36,7 @@ class Parameter(BasicObject):
         'DIMENSION' : reverse('dimension'),
         'AXIS'      : reverse('axis'),
         'ZONES'     : vector('zones'),
+        'VALUES'    : skip(),
     }
 
     linkage = {
@@ -56,53 +61,53 @@ class Parameter(BasicObject):
 
     @property
     def values(self):
-        """ Parameter values uses a dict interface
+        """ Parameter values
 
         Parameter value(s) may be scalar or array's. The size/dimensionallity
-        of each value is defined in the dimensions attribute. The values are
-        only defined in certain zones. If no zones are defined, the value is
-        said to be unzoned, i.e. it is defined everywere.
+        of each value is defined in the dimensions attribute.
+
+        Each value may or may not be zoned, i.e. it is only defined in a
+        certain zone. If this is the case the first zone, parameter.zones[0],
+        will correspond to the first value, parameter.values[0] and so on.  If
+        there is no zones, there should only be one value, which is said to be
+        unzoned, i.e. it is defined everywere.
+
+        Raises
+        ------
+
+        ValueError
+            Unable to structure the values based on the information available.
 
         Returns
         -------
 
-        values : dict
-            indexed by Zone
+        values : structured np.ndarray
 
         Notes
         -----
 
-        If there is no values or DLISIO is unable to structure the samples due
-        to insufficient or contradictory information in the object, the
-        unstructured array is return as is and can be accessed under the label
-        *RAW*. Note that in this case the standard deem the meaning of the
-        values to be undefined.
-
-        If Zones are missing, DLISIO uses defaulted zonelabels.
+        If dlisio is unable to structure the values due to insufficient or
+        contradictory information in the object, an ValueError is raised.  The
+        raw array can still be accessed through attic, but note that in this
+        case, the semantic meaning of the array is undefined.
 
         Examples
         --------
 
-        Values from a spesific zone:
+        First value:
 
-        >>> parameter.values['ZONE-C']
+        >>> parameter.values[0]
         [10, 20, 30]
 
-        Values from each zone:
+        Zone (if any) where that parameter value is valid:
 
-        >>>  zone, value in parameter.values.items():
-        ...     print(zone, value)
-        'ZONE-A' [120, 130, 140]
-        'ZONE-B' [160, 170, 180]
+        >>> parameter.zones[0]
+        Zone('ZONE-A')
         """
         try:
-            data = self.attic['VALUES']
+            values = self.attic['VALUES']
         except KeyError:
-            return {'RAW' : np.empty(0)}
+            return np.empty(0)
 
-        try:
-            sampled = sampling(data, self.dimension, count=len(self.zones))
-        except ValueError:
-            return {'RAW' : np.array(data)}
-
-        return zonify(self.zones, sampled)
+        shape = validshape(values, self.dimension, samplecount=len(self.zones))
+        return sampling(values, shape)

--- a/python/dlisio/plumbing/path.py
+++ b/python/dlisio/plumbing/path.py
@@ -10,17 +10,14 @@ class Path(BasicObject):
     are combined to define part or all of a Data Path, and variation in the
     alignment.
 
-
     Attributes
     ----------
 
     frame_type : Frame
         The frame in which the channel's of the current path are recorded.
 
-    well_reference_point : Well Reference Point
-        Well reference point reference the Object in the current Logical File
-        that specifies the Well Reference Point for entities specified by the
-        remaining Attributes of the Path Object.
+    well_reference_point : Wellref
+        Well Reference Point
 
     value : list of Channel
         Value Channel for the current Path.

--- a/python/dlisio/plumbing/path.py
+++ b/python/dlisio/plumbing/path.py
@@ -1,7 +1,9 @@
-
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector
 from .linkage import obname
+from .utils import describe_dict, replist
+
+from collections import OrderedDict
 
 
 class Path(BasicObject):
@@ -77,3 +79,24 @@ class Path(BasicObject):
         self.measure_point_offset = None
         self.tool_zero_offset     = None
         self.vertical_depth       = None
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Frame']                = replist(self.frame, 'name')
+        d['Well reference point'] = replist(self.well_reference_point, 'name')
+        d['Value Channel(s)']     = replist(self.value, 'name')
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Borehole depth'] = self.borehole_depth
+        d['Vertical depth'] = self.vertical_depth
+        d['Radial drift']   = self.radial_drift
+        d['Angular drift']  = self.angular_drift
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Time']                 = self.time
+        d['Depth offset']         = self.depth_offset
+        d['Measure point offset'] = self.measure_point_offset
+        d['Tool zero offset']     = self.tool_zero_offset
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/process.py
+++ b/python/dlisio/plumbing/process.py
@@ -1,4 +1,3 @@
-
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector
 from .linkage import obname
@@ -11,13 +10,14 @@ class Process(BasicObject):
 
     Attributes
     ----------
+
     description : str
 
     trademark_name  : str
         Trademark name refers to the process and its products.
 
     version : str
-        Version attribute is the producer software version of the process.
+        Software version.
 
     properties : list of str
         Properties that applies to the output of the process, as a result of
@@ -51,7 +51,7 @@ class Process(BasicObject):
     -----
 
     The Process object reflects the logical record type Process, defined in
-    rp66. SPLICE records are listed in Appendix A.2 - Logical Record Types and
+    rp66. PROCESS records are listed in Appendix A.2 - Logical Record Types and
     described in detail in Chapter 5.8.5 - Static and Frame Data, Process
     objects.
     """
@@ -80,7 +80,7 @@ class Process(BasicObject):
 
     def __init__(self, obj = None, name = None):
         super().__init__(obj, name = name, type = 'PROCESS')
-        self.desccription        = None
+        self.description         = None
         self.trademark_name      = None
         self.version             = None
         self.properties          = []

--- a/python/dlisio/plumbing/process.py
+++ b/python/dlisio/plumbing/process.py
@@ -1,6 +1,9 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector
 from .linkage import obname
+from .utils import *
+
+from collections import OrderedDict
 
 
 class Process(BasicObject):
@@ -91,3 +94,25 @@ class Process(BasicObject):
         self.output_computations = []
         self.parameters          = []
         self.comments            = []
+
+    def describe_attr(self, buf, width, indent, exclude):
+        describe_description(buf, self.description, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Trademark name'] = self.trademark_name
+        d['Status']         = self.status
+        d['Version']        = self.version
+        d['Comments']       = self.comments
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Properties']  = self.properties
+        d['Parameters']  = replist(self.parameters, 'name')
+        describe_dict(buf, d, width, indent, exclude)
+
+        d = OrderedDict()
+        d['Input Channels']      = replist(self.input_channels, 'name')
+        d['Output Channels']     = replist(self.output_channels, 'name')
+        d['Input Computations']  = replist(self.input_computations, 'name')
+        d['Output computations'] = replist(self.output_computations, 'name')
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/splice.py
+++ b/python/dlisio/plumbing/splice.py
@@ -1,6 +1,9 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector
 from .linkage import obname
+from .utils import describe_dict, replist
+
+from collections import OrderedDict
 
 
 class Splice(BasicObject):
@@ -66,3 +69,11 @@ class Splice(BasicObject):
         self.output_channel  = None
         self.input_channels  = []
         self.zones           = []
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Zones'] = replist(self.zones, 'name')
+        d['Output Channel'] = replist(self.output_channel, 'name')
+        d['Input Channels'] = replist(self.input_channels, 'name')
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/tool.py
+++ b/python/dlisio/plumbing/tool.py
@@ -1,6 +1,9 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar, vector, boolean
 from .linkage import obname
+from .utils import *
+
+from collections import OrderedDict
 
 class Tool(BasicObject):
     """
@@ -60,3 +63,23 @@ class Tool(BasicObject):
 
         #: Parameter that directly affect or reflect the operation of the tool
         self.parameters      = []
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Description']    = self.description
+        d['Trademark name'] = self.trademark_name
+        d['Generic name']   = self.generic_name
+        d['Status']         = self.status
+
+        describe_dict(buf, d, width, indent, exclude)
+
+        channels = replist(self.channels, 'name')
+        parameters = replist(self.parameters, 'name')
+        parts = replist(self.parts, 'name')
+
+        d = OrderedDict()
+        d['Channels']   = channels
+        d['Parameters'] = parameters
+        d['Parts']      = parts
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/dlisio/plumbing/utils.py
+++ b/python/dlisio/plumbing/utils.py
@@ -1,6 +1,7 @@
 import logging
 import numpy as np
 
+from collections import OrderedDict, Sequence
 from textwrap import fill
 
 
@@ -45,6 +46,8 @@ def validshape(data, shape, samplecount=None):
         a shape that can be used to reshape the data
     """
     error  = 'cannot reshape array of size {} into shape {}'
+
+    if not issequence(data): return [1]
 
     size = len(data)
     if size == 0: return shape
@@ -104,6 +107,7 @@ def sampling(data, shape, single=False):
     array([[1, 2, 3],
            [3, 4, 5])
     """
+    if not issequence(data): return np.empty(0)
 
     size = len(data)
     if size == 0: return np.empty(0)
@@ -131,3 +135,254 @@ def sampling(data, shape, single=False):
         return array[0]
 
     return array
+
+class Summary():
+    """Summary of metadata object"""
+    def __init__(self, info=None):
+        self.info = info
+
+    def __repr__(self):
+        return self.info
+
+def headerinfo(obj):
+    """Get headerinfo from object"""
+    d = OrderedDict()
+    d['name']   = obj.name
+    d['origin'] = obj.origin
+    d['copy']   = obj.copynumber
+    return d
+
+def parseoptions(fmt):
+    """"Create a dict with option based fmt-string"""
+    modes = set([x for x in fmt])
+
+    options = {
+        'attr'  : False,
+        'empty' : False,
+        'head'  : False,
+        'stash' : False,
+        'inv'   : False,
+        'refs'  : False,
+    }
+
+    if 'e' in modes: options['empty'] = True
+    if 'a' in modes: options['attr']  = True
+    if 'h' in modes: options['head']  = True
+    if 'i' in modes: options['inv']   = True
+    if 's' in modes: options['stash'] = True
+    if 'r' in modes: options['refs']  = True
+    return options
+
+def issequence(obj):
+    """Check if object is a sequence, but ignore string and bytes objects"""
+    if isinstance(obj, str): return False
+    if isinstance(obj, bytes): return False
+    return isinstance(obj, (Sequence, np.ndarray))
+
+def remove_empties(d):
+    """Drop entries with no value. '0' is considered to be a valid value."""
+    clean = OrderedDict()
+    for key, value in d.items():
+        if issequence(value):
+            if np.array_equal(np.array(value), np.empty(0)): continue
+        else:
+            if not value and value != 0: continue
+
+        clean[key] = value
+
+    return clean
+
+def replist(elements, mode):
+    """Customize representation of metadata objects. Elements that are not
+    derived from BasicObject are represented as is.
+
+    Attributes
+    ----------
+
+    elements : list_like
+
+    mode : str
+        How metadata objects should be represented [1]
+
+
+    Returns
+    -------
+
+    replist : list of str
+
+    Notes
+    -----
+
+    [1] Mode gives the option to choose what information that should be
+    included in the representation string:
+
+    ========== ==================================================
+    mode       Description
+    ========== ==================================================
+    'name'     names as repr, e.g 'TIME'
+    'typename' type and name as repr, e.g 'Channel('TIME')'
+
+    otherwise  full representation with type, name, origin, copy
+    ========== ==================================================
+    """
+    from .basicobject import BasicObject
+
+    try:
+        elements = list(elements)
+    except TypeError:
+        return elements
+
+    reprs = []
+
+    for x in elements:
+        if not issubclass(x.__class__, BasicObject):
+            reprs.append(str(x))
+            continue
+
+        if mode == 'name':
+            rep = x.name
+        elif mode == 'typename':
+            rep = repr(x)
+        else:
+            rep = '{}({}, {}, {})'.format(
+                x.type.capitalize(),
+                x.name,
+                x.origin,
+                x.copynumber
+            )
+
+        reprs.append(rep)
+
+    return reprs
+
+def describe_header(buf, text, width, indent, lvl=1):
+    """Create a header or a section header"""
+    if text is None: return text
+
+    if lvl == 1:
+        sep = ''.join('-' for _ in range(len(text)))
+        text = [sep, text, sep]
+    elif lvl == 2:
+        sep = '--'
+        text = [text, '--']
+
+    for line in text:
+        describe_text(buf, line, width, indent)
+
+def describe_description(buf, description, width, indent, exclude):
+    """If description references a long_name objects, use its describe. Else
+    print as is."""
+    if not description and exclude['empty']: return None
+
+    try:
+        ln = description.describe(width=width, indent=indent, exclude='hes')
+        describe_header(buf, 'Description', width, indent, lvl=2)
+        buf.write(repr(ln))
+
+    except AttributeError:
+            d = {'Description' : description}
+            describe_dict(buf, d, width, indent, exclude)
+
+def describe_sampled_attrs(buf, attic, dims, valuekey, extras, width, indent,
+        exclude, single=True):
+    """Describe attributes that needs to be sampled (re-shaped)"""
+
+    valids, invs = OrderedDict(), OrderedDict()
+    try:
+        value = attic[valuekey]
+        shape = validshape(value, dims)
+        valids['Value(s)'] = sampling(value, shape)
+    except KeyError:
+        pass
+    except ValueError:
+        invs['Value(s)'] = value
+
+    if extras:
+        for label, key in extras.items():
+            try:
+                value = attic[key]
+                shape = validshape(value, dims)
+                valids[label] = sampling(value, shape, single=single)
+            except KeyError:
+                pass
+            except ValueError:
+                invs[label] = value
+
+    if valids:
+        describe_dict(buf, valids, width, indent, exclude)
+
+    if not exclude['inv'] and invs:
+        describe_header(buf, 'Invalid dimensions', width, indent, lvl=2)
+        describe_dict(buf, invs, width, indent, exclude)
+
+def describe_dict(buf, d, width, indent, exclude=None):
+    """Print a dict nicely into the buffer"""
+
+    if exclude is None: exclude = parseoptions('')
+    if exclude['empty']: d = remove_empties(d)
+
+    if len(d) == 0: return
+
+    keylen = len(max(list(d.keys()), key=len))
+    subindent = ''.ljust(keylen)
+
+    for key, value in d.items():
+        prefix    = ''.join([indent, key.ljust(keylen), ' : '])
+        subindent = ''.ljust(len(prefix))
+
+        if issequence(value):
+            describe_array(buf, value, width, prefix, subindent=subindent, writeempty=True)
+        else:
+            describe_text(buf, value, width, prefix, subindent=subindent)
+    buf.write('\n')
+
+def describe_text(buf, text, width, indent, subindent=None):
+    """Wrap text with textwrapper and write to the buffer"""
+
+    if subindent is None: subindent = indent
+
+    if text is None: text = str(None)
+    wrapped = fill(
+        str(text),
+        width             = width,
+        initial_indent    = indent,
+        subsequent_indent = subindent
+    )
+    buf.write(wrapped)
+    buf.write('\n')
+
+def describe_array(buf, a, width, indent, subindent=None, writeempty=False):
+    """Write a list into the buffer in a nice printable way"""
+    if subindent is None: subindent = indent
+
+    a = np.array(a)
+    if len(a) == 0 and not writeempty:
+        return
+
+    if len(a) == 0 and writeempty:
+        describe_text(buf, [], width, indent, subindent)
+        return
+
+    if a.size == 1:
+        describe_text(buf, a[0], width, indent, subindent)
+        return
+
+    sep = ' '
+    if a.ndim > 1:
+        # Let numpy's array2string handle multidimensional arrays
+        buf.write(indent)
+        samples = np.array2string(
+            a,
+            prefix = subindent,
+            separator = sep,
+            max_line_width = width
+        )
+        buf.write(samples)
+        buf.write('\n')
+        return
+
+    reprs = [str(x) for x in a]
+
+    maxlen = len(max(reprs, key=len))
+    text = sep.join([x.ljust(maxlen) for x in reprs])
+    describe_text(buf, text, width, indent, subindent=subindent)

--- a/python/dlisio/plumbing/utils.py
+++ b/python/dlisio/plumbing/utils.py
@@ -1,83 +1,23 @@
 import logging
 import numpy as np
 
-
-def zonelabels(zones, default):
-    """ Creates a list of labels
-
-    Uses Zone.name as a label. If there are multiple zones with the same name,
-    Zone.labelfmt is used to distinguish them. If no name if found e.g. the
-    zone is None, a default label specifying the number of the zone is used.
-
-    Parameters
-    ----------
-
-    zones : list_like of Zone
-        Missing Zone's can be None
-
-    default : str
-        deafault label to use for missing Zones
-
-    Returns
-    -------
-
-    labels : np.array of str
-    """
-    if len(zones) == 0: return np.array(['DLISIO-UNZONED'])
-
-    labels = []
-    seen = {}
-
-    for i, current in enumerate(zones):
-        try:
-            label = current.name
-        except AttributeError:
-            label = default + str(i)
-
-        if label in seen:
-            # Update the old zone with the same name
-            previdx  = seen[label]
-            prev     = zones[previdx]
-            extended = prev.labelfmt.format(
-                prev.name,
-                prev.origin,
-                prev.copynumber
-            )
-
-            labels[previdx] = extended
-            seen[extended] = previdx
-
-            label = current.labelfmt.format(
-                current.name,
-                current.origin,
-                current.copynumber
-            )
-
-            if label == extended:
-                msg  = 'Found duplicated zones (standard violation), '
-                msg += 'unable to create unique labels'
-                logging.warning(msg)
-
-        labels.append(label)
-        seen[label] = i
-
-    return np.array(labels)
+from textwrap import fill
 
 
-def sampling(data, shape, count=1):
-    """
-    Samplify takes a flat array and returns a structured numpy array, where each
-    sample is shaped by shape, i.e. each sample may be scalar or ndarray.
+def validshape(data, shape, samplecount=None):
+    """Return a valid shape that can be used to sample the data.
+    For a shape to be valid, the following relationship must hold::
 
-    To structure the array this relationship need to hold [1]:
+        len(data) % prod(shape) == 0
 
-        len(data) % prod(dimensions) == 0
+    In case it does not, validshape will try to infer a new shape:
 
-    [1] If there is no dimensions and only one sample in data, then the output array
-        has one scalar sample.
-        If there is no dimensions, the relationship can be re-evaluated with
-        prod(dimensions) = count, where count is a guess on the samplecount
+    - if data has one element, which is a common case, it is safe to assume
+    that shape = [1]
 
+    - If len(data) == samplecount. This is useful in cases where the structured
+    array is closly linked with e.g. number of zones. Hence len(zones) can be
+    uses as a guess for the samplecount.
 
     Parameters
     ----------
@@ -89,8 +29,57 @@ def sampling(data, shape, count=1):
         shape of each sample, follows definition by rp66. E.g. [2, 3] is a 2-d
         array with size 2 x 3
 
-    count : int
-        a guess on the samplecount, in case the there is no shape
+    samplecount : int
+        a guess of how many samples the structured data should have
+
+    Raises
+    ------
+
+    ValueError
+        No valid shape is found
+
+    Returns
+    -------
+
+    shape : list
+        a shape that can be used to reshape the data
+    """
+    error  = 'cannot reshape array of size {} into shape {}'
+
+    size = len(data)
+    if size == 0: return shape
+
+    if shape == []:
+        if   len(data) == samplecount : shape = [1]
+        elif len(data) == 1           : shape = [1]
+        else: raise ValueError(error.format(size, shape))
+
+    samplesize = np.prod(np.array(shape))
+
+    if not size % samplesize: return shape
+    raise ValueError(error.format(size, shape))
+
+def sampling(data, shape, single=False):
+    """Samplify takes a flat array and returns a structured numpy array, where
+    each sample is shaped by shape, i.e. each sample may be scalar or ndarray.
+
+    To structure the array, sampling assumes that this relationship holds::
+
+        len(data) % prod(shape) == 0
+
+    Parameters
+    ----------
+
+    data : 1-d list_like
+        list to be reshaped
+
+    shape : list
+        shape of each sample, follows definition by rp66. E.g. [2, 3] is a 2-d
+        array with size 2 x 3
+
+    single : boolean
+        return only the first sample from the sampled array, even if there is
+        more. In that case this is logged as info.
 
     Returns
     -------
@@ -115,69 +104,30 @@ def sampling(data, shape, count=1):
     array([[1, 2, 3],
            [3, 4, 5])
     """
-    data = np.array(data)
-    if len(data) == 0: raise ValueError('no data')
-    if len(shape) == 0:
-        if len(data) == count:
-            shape = [1]
 
-        else:
-            msg  = 'Empty dimensions, unable to structure array. '
-            msg += 'By definition, the standard (rp66) declares the '
-            msg += 'array to be undefined'
-            logging.warning(msg)
-            raise ValueError(msg)
-
-    raw_elements    = len(data)
-    sample_elements = int(np.product(np.array(shape)))
-
-    if sample_elements == 0:
-        msg = 'invalid dimensions, was {}'.format(shape)
-        logging.warning(msg)
-        raise ValueError(msg)
-
+    size = len(data)
+    if size == 0: return np.empty(0)
     if shape == [1]: shape = 1
 
-    if raw_elements % sample_elements:
-        msg  = 'Unable to shape array due to inconsistent dimensions. '
-        msg += 'list of len={} cannot be shaped into a even number of '
-        msg += 'samples of shape {}'
-        msg.format(raw_elements, shape)
-        raise ValueError(msg)
+    samplesize = np.prod(np.array(shape))
+    samplecount = size // samplesize
 
-    samplecount = int(raw_elements / sample_elements)
+    #TODO: Properly handle types that evaluates to dtype(object) by numpy
+    if isinstance(data[0], tuple):
+        elem_shape = (len(data[0]), )
+    else:
+        elem_shape = ()
 
-    dtype = np.dtype((data.dtype, shape))
+    data = np.array(data)
+    elem_dtype = np.dtype((data.dtype, elem_shape))
+
+    dtype = np.dtype((elem_dtype, shape))
     array = np.ndarray(shape=(samplecount,), dtype=dtype, buffer=data)
+
+    if single:
+        if len(array) != 1:
+            msg = 'found {} samples, should be 1'
+            logging.warning(msg.format(len(array)))
+        return array[0]
+
     return array
-
-
-def zonify(zones, samples, defaultlabel=None):
-    """ Index samples by zone-names
-
-    Parameters
-    ----------
-
-    zones : list_like of Zone
-
-    samples : list_like
-        structured array where each element should correspond to a zone.
-
-    Returns
-    -------
-
-    zoned : dict
-        dict of samples, indexed by Zone
-    """
-    if defaultlabel is None: defaultlabel = 'DLISIO-UNDEF-'
-
-    zones = zonelabels(zones, defaultlabel)
-
-    if len(zones) != len(samples):
-        msg  = 'Number of samples ({}), does not match number of zones ({}). '
-        msg += 'Using default labels for zone indexing.'
-        msg.format(len(samples), len(zones))
-
-        return {defaultlabel + str(i) : value for i, value in enumerate(samples)}
-
-    return {key : value for key, value in zip(zones, samples)}

--- a/python/dlisio/plumbing/wellref.py
+++ b/python/dlisio/plumbing/wellref.py
@@ -9,23 +9,23 @@ class Wellref(BasicObject):
     ----------
 
     permanent_datum : str
-        Permanent datum defines level from where vertical distance is measured
+        Level from where vertical distance is measured
 
     vertical_zero : str
         Vertical zero is an entity that corresponds to zero depth.
 
-    permanent_datum_elevation :
+    permanent_datum_elevation
         Permanent datum, structure or entity from which the vertical distance
         can be measured.
 
-    above_permanent_datum :
+    above_permanent_datum
         Distance of permanent Datum above mean sea level. Negative values
         indicates that the Permanent datum is below mean sea level
 
-    magnetic_declination :
-        Magnetic Declination is  angle between  the line of direction to
-        geographic north and the line of direction to magnetic north. This
-        defines angle with vertex at well reference point.
+    magnetic_declination
+        Angle between  the line of direction to geographic north and the line
+        of direction to magnetic north. This defines angle with vertex at well
+        reference point.
 
     coordinate : dict
         Independent spatial coordinates. Typically, latitude, longitude and

--- a/python/dlisio/plumbing/wellref.py
+++ b/python/dlisio/plumbing/wellref.py
@@ -1,5 +1,9 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar, skip
+from .utils import *
+
+from collections import OrderedDict
+
 
 class Wellref(BasicObject):
     """
@@ -81,3 +85,16 @@ class Wellref(BasicObject):
             key = self.attic.get(name.format(i), [custom_label.format(i)])[0]
             val = self.attic.get(value.format(i), [None])[0]
             self.coordinates[key] = val
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Permanent datum']           =  self.permanent_datum
+        d['Vertical zero']             =  self.vertical_zero
+        d['Permanent datum elevation'] =  self.permanent_datum_elevation
+        d['Above permanent datum']     =  self.above_permanent_datum
+        d['Magnetic declination']      =  self.magnetic_declination
+
+        describe_dict(buf, d, width, indent, exclude)
+
+        describe_header(buf, 'Coordinates', width, indent, lvl=2)
+        describe_dict(buf, self.coordinates, width, indent, exclude)

--- a/python/dlisio/plumbing/zone.py
+++ b/python/dlisio/plumbing/zone.py
@@ -27,7 +27,6 @@ class Zone(BasicObject):
         'MINIMUM'    : scalar('minimum')
     }
 
-    labelfmt = '{:s}.{:d}.{:d}'
 
     def __init__(self, obj = None, name = None):
         super().__init__(obj, name = name, type = 'ZONE')
@@ -41,7 +40,3 @@ class Zone(BasicObject):
         self.maximum     = None
         #: Earliest time or shallowest point, inclusive
         self.minimum     = None
-
-        #: Instance-specific label for duplicated mnemonics.
-        #: Defaults to Zone.labelfmt
-        self.labelfmt = self.labelfmt

--- a/python/dlisio/plumbing/zone.py
+++ b/python/dlisio/plumbing/zone.py
@@ -1,5 +1,8 @@
 from .basicobject import BasicObject
 from .valuetypes import scalar
+from .utils import describe_dict
+
+from collections import OrderedDict
 
 
 class Zone(BasicObject):
@@ -40,3 +43,11 @@ class Zone(BasicObject):
         self.maximum     = None
         #: Earliest time or shallowest point, inclusive
         self.minimum     = None
+
+    def describe_attr(self, buf, width, indent, exclude):
+        d = OrderedDict()
+        d['Description'] = self.description
+        d['Domain']      = self.domain
+        d['Interval']    = '[{}, {})'.format(self.minimum, self.maximum)
+
+        describe_dict(buf, d, width, indent, exclude)

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 import dlisio
 

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -342,7 +342,7 @@ def test_parameter(DWL206):
     assert param.axis       == []
     assert param.zones      == []
 
-    assert list(param.values['RAW'])    == ['DOWNLOG_ONLY']
+    assert param.values[0] == 'DOWNLOG_ONLY'
     assert len(list(DWL206.parameters)) == 226
 
 
@@ -360,12 +360,15 @@ def test_measurement(DWL206):
     assert m.begin_time      == datetime(2011, 8, 20, 18, 13, 38)
     assert m.duration        == 30
     assert m.standard        == []
-    assert list(m.samples)         == [2.640824317932129]
-    assert list(m.max_deviation)   == [11.421565055847168]
-    assert list(m.std_deviation)   == [3.4623820781707764]
-    assert list(m.reference)       == [0.0]
-    assert list(m.plus_tolerance)  == []
-    assert list(m.minus_tolerance) == []
+
+    assert np.array_equal(m.samples , np.array([2.640824317932129]))
+
+    assert m.max_deviation   == 11.421565055847168
+    assert m.std_deviation   == 3.4623820781707764
+    assert m.reference       == 0.0
+
+    assert np.array_equal(m.plus_tolerance , np.empty(0))
+    assert np.array_equal(m.minus_tolerance, np.empty(0))
 
     assert len(list(DWL206.measurements)) == 6
 

--- a/python/tests/test_semantics.py
+++ b/python/tests/test_semantics.py
@@ -291,11 +291,11 @@ def test_parameter(f):
 
     sample = np.reshape(np.array([1, 2, 3, 4, 5, 6]), (2,3))
 
-    assert np.array_equal(p.values['ZONE-A'], sample)
-    assert np.array_equal(p.values['DLISIO-UNDEF-1'][1], np.array([10, 11, 12]))
+    assert np.array_equal(p.values[0], sample)
+    assert np.array_equal(p.values[1][1], np.array([10, 11, 12]))
 
-    assert p.values['DLISIO-UNDEF-2'][0][1] == 14
-    assert p.values['DLISIO-UNDEF-3'][1][2] == 24
+    assert p.values[2][0][1] == 14
+    assert p.values[3][1][2] == 24
 
     key = fingerprint('PARAMETER', 'PARAM1', 10, 0)
     p = f.objects[key]
@@ -304,7 +304,7 @@ def test_parameter(f):
 
     assert p.long_name == longname
 
-    value = p.values['ZONE-A']
+    value = p.values[0]
     assert np.array_equal(value, np.array([101, 120]))
 
 def test_equipment(f):
@@ -385,12 +385,12 @@ def test_measurement(f):
     plus    = np.array([[5, 10], [5, 10], [5, 10]])
     minus   = np.array([[1, 1], [1, 1], [1, 1]])
 
-    assert np.array_equal(m.samples[0]         , samples)
-    assert np.array_equal(m.max_deviation[0]   , maxdev)
-    assert np.array_equal(m.std_deviation[0]   , stddev)
-    assert np.array_equal(m.reference[0]       , ref)
-    assert np.array_equal(m.plus_tolerance[0]  , plus)
-    assert np.array_equal(m.minus_tolerance[0] , minus)
+    assert np.array_equal(m.samples[0]      , samples)
+    assert np.array_equal(m.max_deviation   , maxdev)
+    assert np.array_equal(m.std_deviation   , stddev)
+    assert np.array_equal(m.reference       , ref)
+    assert np.array_equal(m.plus_tolerance  , plus)
+    assert np.array_equal(m.minus_tolerance , minus)
 
 def test_coefficient(f):
     key = fingerprint('CALIBRATION-COEFFICIENT', 'COEFF1', 10, 0)
@@ -464,7 +464,7 @@ def test_computation(f):
     assert com.source             == process
 
     values  = np.array([[140, 99], [144, 172], [202, 52], [109, 120]])
-    assert np.array_equal(com.values[zone.name], values)
+    assert np.array_equal(com.values[0], values)
 
 
 def test_splice(f):

--- a/python/tests/test_semantics.py
+++ b/python/tests/test_semantics.py
@@ -70,6 +70,8 @@ def test_file_header(f):
     assert fh.sequencenr == "8"
     assert fh.id         == "some logical file"
 
+    _ = fh.describe(indent='   ', width=70, exclude='e')
+
 def test_origin(f):
     key = fingerprint('ORIGIN', 'DEFINING_ORIGIN', 10, 0)
     def_origin = f.objects[key]
@@ -104,6 +106,8 @@ def test_origin(f):
     assert random_origin.file_set_nr == 1042
     assert random_origin.file_nr     == 6
 
+    _ = random_origin.describe(indent='   ', width=70, exclude='e')
+
 def test_axis(f):
     key = fingerprint('AXIS', 'AXIS2', 10, 0)
     axis = f.objects[key]
@@ -111,6 +115,8 @@ def test_axis(f):
     assert axis.axis_id     == 'AX2'
     assert axis.coordinates == ['very near', 'not so far']
     assert axis.spacing     == 'a bit'
+
+    _ = axis.describe(indent='   ', width=70, exclude='e')
 
 def test_longname(f):
     key = fingerprint('LONG-NAME', 'CHANN1-LONG-NAME', 10, 0)
@@ -131,6 +137,8 @@ def test_longname(f):
     assert ln.conditions      == ['at standard temperature']
     assert ln.standard_symbol == 'SYM'
     assert ln.private_symbol  == 'BOL'
+
+    _ = ln.describe(indent='   ', width=70, exclude='e')
 
 def test_channel(f):
     key = fingerprint('TOOL', 'TOOL1', 10, 0)
@@ -164,6 +172,8 @@ def test_channel(f):
     assert channel.element_limit          == [11, 15, 10]
     assert channel.attic["ELEMENT-LIMIT"] == [10, 15, 11]
     assert channel.source                 == tool
+
+    _ = channel.describe(indent='   ', width=70, exclude='e')
 
 def test_channel_fdata(f):
     key = fingerprint('CHANNEL', 'CHANN1', 10, 0)
@@ -268,6 +278,8 @@ def test_zone(f):
     assert zone.maximum     == 13398
     assert zone.minimum     == 8603
 
+    _ = zone.describe(indent='   ', width=70, exclude='e')
+
 def test_parameter(f):
     key = fingerprint('PARAMETER', 'PARAM3', 10, 0)
     p = f.objects[key]
@@ -307,6 +319,8 @@ def test_parameter(f):
     value = p.values[0]
     assert np.array_equal(value, np.array([101, 120]))
 
+    _ = p.describe(indent='   ', width=70, exclude='e')
+
 def test_equipment(f):
     key = fingerprint('EQUIPMENT', 'EQUIP1', 10, 0)
     e = f.objects[key]
@@ -327,6 +341,8 @@ def test_equipment(f):
     assert e.vertical_depth == 103
     assert e.radial_drift   == 130
     assert e.angular_drift  == 41
+
+    _ = e.describe(indent='   ', width=70, exclude='e')
 
 def test_tool(f):
     key = fingerprint('EQUIPMENT', 'EQUIP1', 10, 0)
@@ -353,6 +369,8 @@ def test_tool(f):
     assert tool.channels                == [channel1, channel2]
     assert tool.parameters              == [param1, None, param2]
     assert len(tool.refs["parameters"]) == 3
+
+    _ = tool.describe(indent='   ', width=70, exclude='e')
 
 def test_measurement(f):
     key = fingerprint('TOOL', 'TOOL1', 10, 0)
@@ -392,6 +410,8 @@ def test_measurement(f):
     assert np.array_equal(m.plus_tolerance  , plus)
     assert np.array_equal(m.minus_tolerance , minus)
 
+    _ = m.describe(indent='   ', width=70, exclude='e')
+
 def test_coefficient(f):
     key = fingerprint('CALIBRATION-COEFFICIENT', 'COEFF1', 10, 0)
     c = f.objects[key]
@@ -401,6 +421,8 @@ def test_coefficient(f):
     assert c.references      == [18, 32]
     assert c.plus_tolerance  == [1, 1]
     assert c.minus_tolerance == [2, 1]
+
+    _ = c.describe(indent='   ', width=70, exclude='e')
 
 def test_calibration(f):
     key = fingerprint('PARAMETER', 'PARAM1', 10, 0)
@@ -439,6 +461,8 @@ def test_calibration(f):
     assert c.parameters   == [param1, param2, param3]
     assert c.method       == "USELESS"
 
+    _ = c.describe(indent='   ', width=70, exclude='e')
+
 def test_computation(f):
     key = fingerprint('COMPUTATION', 'COMPUT2', 10, 0)
     com = f.objects[key]
@@ -466,6 +490,7 @@ def test_computation(f):
     values  = np.array([[140, 99], [144, 172], [202, 52], [109, 120]])
     assert np.array_equal(com.values[0], values)
 
+    _ = com.describe(indent='   ', width=70, exclude='e')
 
 def test_splice(f):
     key = fingerprint('SPLICE', 'SPLICE1', 10, 0)
@@ -494,6 +519,7 @@ def test_splice(f):
     assert splice.refs['zones'][1].origin     == 10
     assert splice.refs['zones'][1].copynumber == 0
 
+    _ = splice.describe(indent='   ', width=70, exclude='e')
 
 def test_wellref(f):
     key = fingerprint('WELL-REFERENCE', 'THE-WELL', 10, 0)
@@ -509,6 +535,7 @@ def test_wellref(f):
     assert wellref.coordinates['latitude']   == 60.75
     assert wellref.coordinates['elevation']  == 0.25
 
+    _ = wellref.describe(indent='   ', width=70, exclude='e')
 
 def test_group(f):
     key = fingerprint('GROUP', 'GROUP1', 10, 0)
@@ -551,6 +578,7 @@ def test_group(f):
     assert g3.groups      == [g1, g2]
     assert g3.objecttype  == 'IGNORE-ME-PLZ'
 
+    _ = g3.describe(indent='   ', width=70, exclude='e')
 
 def test_process(f):
     key = fingerprint('PROCESS', 'PROC1', 10, 0)
@@ -588,6 +616,8 @@ def test_process(f):
     assert p1.output_computations == [oc1]
     assert p1.parameters          == [param1, param3]
     assert p1.comments            == ["It was", "nicely", "executed", "??"]
+
+    _ = p1.describe(indent='   ', width=70, exclude='e')
 
 def test_path(f):
     key = fingerprint('PATH', 'PATH1', 10, 0)
@@ -635,6 +665,7 @@ def test_path(f):
     assert p2.angular_drift        == 64
     assert p2.vertical_depth       == -119
 
+    _ = p2.describe(indent='   ', width=70, exclude='e')
 
 def test_unknown(f):
     key = fingerprint('UNKNOWN_SET', 'OBJ1', 10, 0)
@@ -643,6 +674,8 @@ def test_unknown(f):
     assert unknown.stash["SOME_LIST"]   == ["LIST_V1", "LIST_V2"]
     assert unknown.stash["SOME_VALUE"]  == ["VAL1"]
     assert unknown.stash["SOME_STATUS"] == [1]
+
+    _ = unknown.describe(indent='   ', width=70, exclude='e')
 
 def test_unexpected_attributes(f):
     key = fingerprint('CALIBRATION-COEFFICIENT', 'COEFF_BAD', 10, 0)

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import dlisio
 from dlisio.plumbing import *
 from . import assert_log
+from io import StringIO
 
 def test_sampling_scalar_dims():
     raw = [1, 2, 3, 4, 5, 6]
@@ -86,6 +87,260 @@ def test_validshape_inconsistent_dims():
 
     with pytest.raises(ValueError):
         _ = validshape(raw, dimensions)
+
+def test_issequence():
+    assert not issequence('seq')
+    assert not issequence("seq")
+    assert not issequence("""seq""")
+    assert not issequence(bytes(1))
+
+    assert issequence([1])
+    assert issequence(np.array([1]))
+
+def test_remove_empties():
+    d = OrderedDict()
+    d['a'] = 0
+    d['b'] = 1
+    d['c'] = None
+    d['d'] = np.empty(0)
+    d['e'] = []
+    d['f'] = 'str'
+    d['g'] = ''
+    d['h'] = ""
+
+    ref = OrderedDict()
+    ref['a'] = 0
+    ref['b'] = 1
+    ref['f'] = 'str'
+
+    clean = remove_empties(d)
+    assert clean == ref
+
+def test_replist():
+    ch1 = Channel(name='TIME')
+    ch1.origin = 1
+    ch1.copynumber = 0
+
+    ch2 = Channel(name='TDEP')
+    ch2.origin = 1
+    ch2.copynumber = 1
+
+    channels = [ch1, ch2, None]
+    names    = replist(channels, 'name')
+    typename = replist(channels, 'typename')
+    default  = replist(channels, 'not-a-valid-option')
+
+    assert names    == ['TIME', 'TDEP', 'None']
+    assert typename == ['Channel(TIME)', 'Channel(TDEP)', 'None']
+    assert default  == ['Channel(TIME, 1, 0)', 'Channel(TDEP, 1, 1)', 'None']
+
+    # Elements that are not a subclass of BasicObjects
+    elems = [None , 1, 'str', 2.0]
+    reprs = replist(elems, '')
+    assert reprs == [str(x) for x in elems]
+
+def test_describe_header():
+    # top level header, indented with one whitespace
+    case1 = (' -------\n'
+             ' Channel\n'
+             ' -------\n'
+    )
+
+    # section header, indented with one withspace
+    case2 = (' Index\n'
+             ' --\n'
+    )
+
+    buf = StringIO()
+    describe_header(buf, 'Channel', width=10, indent=' ', lvl=1)
+    assert str(buf.getvalue()) == case1
+
+    buf = StringIO()
+    describe_header(buf, 'Index', 10, ' ', lvl=2)
+    assert str(buf.getvalue()) == case2
+
+def test_sampled_attrs():
+    attic = {
+        'CORRECT' : [1, 2],
+        'WRONG'   : [5, 6, 7],
+        'VALUES'  : [0.5, 0.6, 0.7, 0.8]
+    }
+    dims = [2]
+
+    exclude = parseoptions('e')
+    buf = StringIO()
+
+    d = OrderedDict()
+    d['correct'] = 'CORRECT'
+    d['wrong'] = 'WRONG'
+    d['drop'] = 'NOT-IN-ATTIC'
+
+    describe_sampled_attrs(
+            buf,
+            attic,
+            dims,
+            'VALUES',
+            d,
+            80,
+            ' ',
+            exclude
+    )
+
+    ref = (' Value(s) : [[0.5 0.6]\n'
+           '             [0.7 0.8]]\n'
+           ' correct  : 1 2\n'
+           '\n'
+           ' Invalid dimensions\n'
+           ' --\n'
+           ' wrong : 5 6 7\n\n'
+    )
+
+    assert str(buf.getvalue()) == ref
+
+def test_sampled_attrs_wrong_value():
+    attic = {'VALUES' : [0.5, 0.6, 0.7]}
+    dims = [2]
+
+    exclude = parseoptions('e')
+    buf = StringIO()
+
+    describe_sampled_attrs(
+            buf,
+            attic,
+            dims,
+            'VALUES',
+            {},
+            80,
+            ' ',
+            exclude
+    )
+
+    ref = (
+           ' Invalid dimensions\n'
+           ' --\n'
+           ' Value(s) : 0.5 0.6 0.7\n\n'
+    )
+
+    assert str(buf.getvalue()) == ref
+
+def test_describe_description():
+    ln = Longname()
+    ln.quantity       = 'diameter and stuff'
+    ln.source_part_nr = 10
+
+    # description is a Longname object
+    case1 = (' Description\n'
+             ' --\n'
+             ' Quantity           : diameter\n'
+             '                      and stuff\n'
+             ' Source part number : 10\n\n'
+    )
+
+    buf = StringIO()
+    exclude = parseoptions('e')
+    describe_description(buf, ln, width=31, indent=' ', exclude=exclude)
+    assert str(buf.getvalue()) == case1
+
+    # description is a string
+    case2 = (' Description : string\n'
+             '               desc\n\n'
+    )
+
+    buf = StringIO()
+    describe_description(buf, 'string desc', width=21, indent=' ',
+            exclude=exclude)
+    assert str(buf.getvalue()) == case2
+
+def test_describe_dict():
+    d = OrderedDict()
+    d['desc']  = 'long description'
+    d['list']  = list(range(10))
+    d['empty'] = None
+
+
+    # dict, indented with one whitespace, wrapped at 20 characters
+    case1 = (' desc  : long\n'
+             '         description\n'
+             ' list  : 0 1 2 3 4 5\n'
+             '         6 7 8 9\n'
+             ' empty : None\n\n'
+    )
+
+    buf = StringIO()
+    exclude = parseoptions('')
+    describe_dict(buf, d, width=20, indent=' ', exclude=exclude)
+    assert str(buf.getvalue()) == case1
+
+    # dict, indented with one whitespace, wrapped at 20 characters, where empty
+    # values are ommited
+    case2 = (' desc : long\n'
+             '        description\n'
+             ' list : 0 1 2 3 4 5\n'
+             '        6 7 8 9\n\n'
+    )
+
+    buf = StringIO()
+    exclude = parseoptions('e')
+    describe_dict(buf, d, width=20, indent=' ', exclude=exclude)
+    assert str(buf.getvalue()) == case2
+
+def test_describe_text():
+    text = 'Desc : fra cha'
+
+    # text, indented with a single withspace, wrap on 11 characters, and
+    # subindented such that the 'key' matches up with the above
+    case1 = (' Desc : fra\n'
+             '        cha\n'
+    )
+
+    buf = StringIO()
+    describe_text(buf, text, 11, ' ', subindent=''.ljust(8))
+    assert str(buf.getvalue()) == case1
+
+    # text, indented with a single withspace, wrap on 11 characters, and no
+    # subindent. I.e subindent=indent
+    case2 = (' Desc : fra\n'
+            ' cha\n'
+    )
+
+    buf = StringIO()
+    describe_text(buf, text, 11, ' ')
+    assert str(buf.getvalue()) == case2
+
+def test_describe_array():
+    # describe_array should not write anything to the buffer when supplying an
+    # empty array with writempty=False
+    buf = StringIO()
+    describe_array(buf, [], width=80, indent='  ', subindent='  ',
+            writeempty=False)
+
+    assert buf.getvalue() == StringIO().getvalue()
+
+    # wrap array on 10 characters and indent it by one whitespace.
+    # describe_array should align columns when the elements are of unequal
+    # length
+    case1 = (' 100  2000\n'
+             ' 3000 10\n')
+
+    buf = StringIO()
+    arr = [100, 2000, 3000, 10]
+    describe_array(buf, arr, width=10, indent=' ')
+    assert str(buf.getvalue()) == case1
+
+def test_describe_ndarray():
+    # ndarray's should be handled by numpy's array2string
+
+    # A array where each sample is a 2x2 ndarray, indented by one whitespace
+    case1 = (' [[[ 100 2000]\n'
+             '   [3000   10]]\n'
+             '\n'
+             '  [[  20   30]\n'
+             '   [3000  200]]]\n')
+
+    arr = np.array([[[100, 2000], [3000, 10]], [[20, 30], [3000, 200]]])
+    buf = StringIO()
+    describe_array(buf, arr, width=20, indent=' ')
+    assert str(buf.getvalue()) == case1
 
 @pytest.mark.parametrize('obj', [Parameter(), Computation()])
 def test_values_empty(obj):


### PR DESCRIPTION
known todo's:

- Add no-op describe() to basicobject w/ documentation
-  tests: at a minimum test that describe() is callable with all parameter
-  tests: test formatter & other utils
- Describe() for dlis (and Batch?)
- some docs for the utils

The dispatching between list_like, dict_like and scalar in formatter.wrap needs some work


