### PR TITLE
Remove initial value for dlis.types in docs

### DIFF
--- a/python/docs/dlisio.rst
+++ b/python/docs/dlisio.rst
@@ -7,8 +7,12 @@ File Handle
 ===========
 .. autoclass:: dlisio.dlis()
     :members:
+    :exclude-members: types
     :member-order: bysource
     :undoc-members:
+
+    .. autoinstanceattribute:: types
+        :annotation: = {}
 
 .. currentmodule:: dlisio.plumbing
 


### PR DESCRIPTION
Remove the very ugly default value for dlis.types [1]. It yields little valuable information to the user:
 https://dlisio.readthedocs.io/en/latest/dlisio.html#file-handle