### PR TITLE
Upgrade required version of pybind11 to v2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To develop dlisio, or to build a particular revision from source, you need:
 * [CMake](https://cmake.org/) version 3.5 or greater
 * [Python](https://python.org) version 3.5 or greater
 * [fmtlib](http://fmtlib.net/) tested mainly with 5.3.0
-* [pybind11](https://github.com/pybind/pybind11) version 2.2 or greater
+* [pybind11](https://github.com/pybind/pybind11) version 2.3 or greater
 * [setuptools](https://pypi.python.org/pypi/setuptools) version 28 or greater
 * python packages pytest, pytest-runner, and numpy
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -57,7 +57,7 @@ skbuild.setup(
     platforms = 'any',
     install_requires = ['numpy'],
     setup_requires = ['setuptools >= 28',
-                      'pybind11 >= 2.2',
+                      'pybind11 >= 2.3',
                       'setuptools_scm',
                       'pytest-runner',
     ],


### PR DESCRIPTION
Pybind11 v2.3 broke dlisio, which was fixed in commit
09ee870a9db0d18adef0ae258ec3532f8f7bbaeb. However, the fix is not
compatible with pre v2.3 of pybind11.

Because we always fetch the newest versions of dependancies in our
CI-pipeline, this backward-compabillity issue was not picked up.