### PR TITLE
Add index channel as property on Frame and Channel

### DIFF
--- a/python/dlisio/plumbing/channel.py
+++ b/python/dlisio/plumbing/channel.py
@@ -102,6 +102,22 @@ class Channel(BasicObject):
         self.frame        = None
 
     @property
+    def index(self):
+        """The Channel this Channel is indexed against, if any. See
+        :attr:`Frame.index_type` for definition of existing index channel.
+
+        Returns
+        -------
+
+        channel : Channel or None
+        """
+        msg = 'This channel is an index channel'
+        index = self.frame.index
+
+        if index == self: logging.info(msg)
+        return index
+
+    @property
     def dtype(self):
         """dtype
 

--- a/python/dlisio/plumbing/frame.py
+++ b/python/dlisio/plumbing/frame.py
@@ -118,6 +118,32 @@ class Frame(BasicObject):
         # Defaults to Frame.dtype_format
         self.dtype_fmt = self.dtype_format
 
+    @property
+    def index(self):
+        """The Channel that serves as an index for all other Channels in this
+        Frame.
+
+        Frames may or may not have an index Channel, see :attr:`index_type` for
+        definition of existing index channel.
+
+        Returns
+        -------
+        channel : Channel or None
+        """
+        msg = 'There is no index channel, see help(frame.index) for more info'
+        index = None
+
+        if self.index_type is None:
+            logging.warning(msg)
+            return index
+
+        try:
+            index = self.channels[0]
+        except IndexError:
+            logging.warning(msg)
+
+        return index
+
     @classmethod
     def create(cls, obj, name = None, type = None, file = None):
         self = Frame(obj, name = name, file = file)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 import dlisio
 
@@ -46,6 +47,13 @@ def update_envelope_VRL_and_LRSL(b, lrs_offset = None):
 
 @pytest.fixture
 def assert_log(caplog):
+    def assert_message(message_id):
+        assert any([message_id in r.message for r in caplog.records])
+    return assert_message
+
+@pytest.fixture
+def assert_info(caplog):
+    caplog.set_level(logging.INFO)
     def assert_message(message_id):
         assert any([message_id in r.message for r in caplog.records])
     return assert_message

--- a/python/tests/test_frames.py
+++ b/python/tests/test_frames.py
@@ -19,12 +19,18 @@ def test_frame_getitem(DWL206):
     assert curves[0]['TDEP'] == 852606.0
 
 def makeframe():
+    frame = dlisio.plumbing.Frame()
+    frame.name = 'MAINFRAME'
+    frame.origin = 0
+    frame.copynumber = 0
+
     time0 = dlisio.plumbing.Channel()
     time0.name = 'TIME'
     time0.origin = 0
     time0.copynumber = 0
     time0.dimension = [1]
     time0.reprc = 2 # f4
+    time0.frame = frame
 
     tdep = dlisio.plumbing.Channel()
     tdep.name = 'TDEP'
@@ -32,6 +38,7 @@ def makeframe():
     tdep.copynumber = 0
     tdep.dimension = [2]
     tdep.reprc = 13 # i2
+    tdep.frame = frame
 
     time1 = dlisio.plumbing.Channel()
     time1.name = 'TIME'
@@ -39,11 +46,8 @@ def makeframe():
     time1.copynumber = 0
     time1.dimension = [1]
     time1.reprc = 13 # i2
+    time1.frame = frame
 
-    frame = dlisio.plumbing.Frame()
-    frame.name = 'MAINFRAME'
-    frame.origin = 0
-    frame.copynumber = 0
     frame.channels = [time0, tdep, time1]
 
     return frame
@@ -162,3 +166,46 @@ def test_wrong_linkage(assert_log):
 
     f.link([f])
     assert_log("wrong linkage")
+
+def test_frame_index():
+    frame = makeframe()
+    frame.index_type = 'DECREASING'
+
+    assert frame.index == frame.channels[0]
+
+def test_frame_noindex(assert_info):
+    frame = makeframe()
+
+    assert frame.index is None
+    assert_info('There is no index channel')
+
+def test_frame_nochannels_no_index(assert_info):
+    frame = dlisio.plumbing.Frame()
+    frame.index_type = 'DECREASING'
+
+    assert frame.index == None
+    assert_info('There is no index channel')
+
+def test_channel_index():
+    frame = makeframe()
+    frame.index_type = 'DECREASING'
+
+    index   = frame.channels[0]
+    channel = frame.channels[1]
+
+    assert channel.index == index
+
+def test_channel_is_index(assert_info):
+    frame = makeframe()
+    frame.index_type = 'DECREASING'
+    channel = frame.channels[0]
+
+    assert channel.index == channel
+    assert_info('This channel is an index channel')
+
+def test_channel_noindex(assert_info):
+    frame = makeframe()
+    channel = frame.channels[0]
+
+    assert channel.index is None
+    assert_info('There is no index channel')


### PR DESCRIPTION
When working with curves its integral to know how they are indexed.
From the standard, identifying the index channel for a Frame or another
channel is a bit clumsy:

> The first channel in a Frame is implicitly the index channel _if_
  Frame.index_type is not None. Otherwise, all channels in that frame is
  index by samplenumber.

Adding the index as a property to Frame and Channel relieve the end user
of these details and ensures it is handled correctly.

closes #160