### PR TITLE
Decode string cycle codepages

### DIFF
--- a/python/dlisio/__init__.py
+++ b/python/dlisio/__init__.py
@@ -12,6 +12,89 @@ try:
 except pkg_resources.DistributionNotFound:
     pass
 
+def get_encodings():
+    """Get codepages to use for decoding strings
+
+    Get the currently set codepages used when decoding strings.
+
+    Returns
+    -------
+    encodings : list
+
+    See also
+    --------
+    set_encodings
+    """
+    return core.get_encodings()
+
+def set_encodings(encodings):
+    """Set codepages to use for decoding strings
+
+    RP66 specifies that all strings should be in ASCII, meaning 7-bit. Strings
+    in ASCII have identical bitwise representation in UTF-8, and python strings
+    are in UTF-8. However, a lot of files contain strings that aren't ASCII,
+    but encoded in some way - a common is the degree symbol [1]_, but plenty of
+    files use other encodings too.
+
+    This function sets the code pages that dlisio will try *in order* when
+    decoding strings (IDENT, ASCII, UNITS, and when they appear as members in
+    e.g. ATTREF). UTF-8 will always be tried first, and is always correct if
+    the file behaves according to spec.
+
+    Available encodings can be found in the Python docs [2]_.
+
+    If none of the encodings succeed, all strings will be returned as a bytes
+    object.
+
+    Parameters
+    ----------
+    encodings : list of str
+        Ordered list of encodings to try
+
+    Warns
+    -----
+    UnicodeWarning
+        When no decode was successful, and a bytes object is returned
+
+    Warnings
+    --------
+    There is no place in the DLIS spec to put or look for encoding information,
+    decoding is a wild guess. Plenty of strings are valid in multiple encodings,
+    so there's a high chance that decoding with the wrong encoding will give a
+    valid string, but not the one the writer intended.
+
+    See also
+    --------
+    get_encodings : currently set encodings
+
+    Notes
+    -----
+    Strings are decoded using Python's bytes.decode(errors = 'strict').
+
+    References
+    ----------
+    .. [1] https://stackoverflow.com/questions/8732025/why-degree-symbol-differs
+    .. [2] https://docs.python.org/3/library/codecs.html#standard-encodings
+
+    Examples
+    --------
+    Decoding of the same string under different encodings
+
+    >>> dlisio.set_encodings([])
+    >>> with dlisio.load('file.dlis') as (f, *_):
+    ...     print(getchannel(f).units)
+    b'custom unit\\xb0'
+    >>> dlisio.set_encodings(['latin1'])
+    >>> with dlisio.load('file.dlis') as (f, *_):
+    ...     print(getchannel(f).units)
+    'custom unit°'
+    >>> dlisio.set_encodings(['utf-16'])
+    >>> with dlisio.load('file.dlis') as (f, *_):
+    ...     print(getchannel(f).units)
+    '畣瑳浯甠楮끴'
+    """
+    core.set_encodings(list(encodings))
+
 class dlis(object):
     """Logical file
 

--- a/python/dlisio/ext/core.cpp
+++ b/python/dlisio/ext/core.cpp
@@ -27,6 +27,43 @@ using namespace py::literals;
 #include <dlisio/ext/io.hpp>
 #include <dlisio/ext/types.hpp>
 
+namespace {
+/*
+ * Global list of encodings to try when making UTF-8 strings.
+ *
+ * The encodings are global, which is a result of the current design of dlisio.
+ *
+ * Ideally, what encodings to try should be configurable on a much finer level
+ * - it's quite reasonable to have multiple files open, which both can have
+ * different encodings used. In the future it's quite possible to fine tune it
+ * more, but that requires a larger redesign of dlisio's internals.
+ *
+ * However, in practice the outcome of a global-only configuration is a minor
+ * annoyance at best. DLIS only allows ASCII, so anything that isn't UTF-8
+ * compatible is already non-standard, and it's unlikely there's a need for
+ * opening *many files at once*, all with different encodings. Also, since the
+ * global can be re-set between successive file loads, work-arounds are usually
+ * possible.
+ *
+ * The main reason it has to be global is that strings are converted to python
+ * strings pretty deep in the call graph, using pybind11's casting features.
+ * The casts, however, are unary functions, so no extra parameters there.
+ * Moreover, the compounded dlis types, like ATTREF, rely on the type cast
+ * mechanism in order to convert its members to python types. To resolve this,
+ * a major redesign is needed.
+ */
+std::vector< std::string > encodings = {};
+
+void set_encodings(const std::vector< std::string >& encs) {
+    encodings = encs;
+}
+
+const std::vector< std::string >& get_encodings() {
+    return encodings;
+}
+
+}
+
 namespace pybind11 { namespace detail {
 
 /*
@@ -124,46 +161,39 @@ handle dlis_caster< dl::cdoubl >::cast( const dl::cdoubl& src, return_value_poli
 
 namespace {
 
-handle maybe_decode(const std::string& src) noexcept (false) {
-    try {
-        /* was valid UTF-8, all is well*/
-        return py::str(src).inc_ref();
-    } catch(std::runtime_error& e) {
+handle decode_str(const std::string& src) noexcept (false) {
+    auto* p = PyUnicode_FromString(src.c_str());
+    if (p) return p;
+    PyErr_Clear();
+
+    for (const auto& enc : encodings) {
+        auto* p = PyUnicode_Decode(
+                src.c_str(),
+                src.size(),
+                enc.c_str(),
+                "strict"
+            );
+
+        if (p) return p;
         PyErr_Clear();
-        /*
-         * The degree symbol is weird in UTF-8, but often shows up
-         *
-         * https://stackoverflow.com/questions/8732025/why-degree-symbol-differs-from-utf-8-from-unicode
-         *
-         * Look for this symbol in the string - if it's there, replace it with
-         * the UTF-8 one and try to return that string. If _that_ fails, return
-         * bytes
-         */
-        auto pos = src.find('\xB0');
-
-        // Ok, so it wasn't the degree symbol being encoded wrong - return the
-        // string as bytes and defer decoding to caller
-        if (pos == std::string::npos)
-            return py::bytes(src).inc_ref();
-
-        std::string source(src);
-        source.insert(pos, 1, '\xC2');
-        while ((pos = source.find('\xB0', pos + 2)) != std::string::npos) {
-            source.insert(pos, 1, '\xC2');
-        }
-
-        /*
-         * Now this should be proper unicode. If it isn't, return bytes again
-         *
-         * TODO: Return-as-bytes should probably not be a silent conversion
-         */
-        try {
-            return py::str(source).inc_ref();
-        } catch (std::runtime_error&) {
-            PyErr_Clear();
-            return py::bytes(src).inc_ref();
-        }
     }
+
+    /*
+     * To get a better warning, include the source string. The problem is that
+     * the PyExc_WarnEx (warnings.warn() in python) tries to encode the string
+     * to unicode, which is what triggers the warning in the first place,
+     * meaning C++ string concatenation or stringstreams won't work.
+     *
+     * Instead, work around this by doing '{}'.format(bytes()) to get the
+     * string-representation of the bytes.
+     */
+    auto pysrc = py::bytes(src);
+    const auto pymsg = py::str("unable to decode string {}");
+    const auto msg   = std::string(pymsg.format(pysrc));
+    if (PyErr_WarnEx(PyExc_UnicodeWarning, msg.c_str(), 1) == -1)
+        throw py::error_already_set();
+
+    return pysrc.inc_ref();
 }
 
 }
@@ -171,19 +201,19 @@ handle maybe_decode(const std::string& src) noexcept (false) {
 template <>
 handle dlis_caster< dl::ascii >::cast(const dl::ascii& src, return_value_policy, handle)
 {
-    return maybe_decode(dl::decay(src));
+    return decode_str(dl::decay(src));
 }
 
 template <>
 handle dlis_caster< dl::ident >::cast(const dl::ident& src, return_value_policy, handle)
 {
-    return maybe_decode(dl::decay(src));
+    return decode_str(dl::decay(src));
 }
 
 template <>
 handle dlis_caster< dl::units >::cast(const dl::units& src, return_value_policy, handle)
 {
-    return maybe_decode(dl::decay(src));
+    return decode_str(dl::decay(src));
 }
 
 /*
@@ -866,4 +896,7 @@ PYBIND11_MODULE(core, m) {
         auto marks = dl::findoffsets( file, 80 );
         return py::make_tuple( marks.residuals, marks.tells );
     });
+
+    m.def("set_encodings", set_encodings);
+    m.def("get_encodings", get_encodings);
 }

--- a/python/dlisio/ext/core.cpp
+++ b/python/dlisio/ext/core.cpp
@@ -87,7 +87,7 @@ struct dlis_caster {
     PYBIND11_TYPE_CASTER(T, _("dlisio.core.type.")+_(dl::typeinfo< T >::name));
 
     static handle cast( const T& src, return_value_policy, handle ) {
-        return py::cast( dl::decay( src ) ).inc_ref();
+        return py::cast( dl::decay( src ) ).release();
     }
 
     /*
@@ -126,25 +126,25 @@ handle dlis_caster< dl::dtime >::cast( const dl::dtime& src, return_value_policy
 template <>
 handle dlis_caster< dl::fsing1 >::cast( const dl::fsing1& src, return_value_policy, handle )
 {
-    return py::make_tuple(src.V, src.A).inc_ref();
+    return py::make_tuple(src.V, src.A).release();
 }
 
 template <>
 handle dlis_caster< dl::fsing2 >::cast( const dl::fsing2& src, return_value_policy, handle )
 {
-    return py::make_tuple(src.V, src.A, src.B).inc_ref();
+    return py::make_tuple(src.V, src.A, src.B).release();
 }
 
 template <>
 handle dlis_caster< dl::fdoub1 >::cast( const dl::fdoub1& src, return_value_policy, handle )
 {
-    return py::make_tuple(src.V, src.A).inc_ref();
+    return py::make_tuple(src.V, src.A).release();
 }
 
 template <>
 handle dlis_caster< dl::fdoub2 >::cast( const dl::fdoub2& src, return_value_policy, handle )
 {
-    return py::make_tuple(src.V, src.A, src.B).inc_ref();
+    return py::make_tuple(src.V, src.A, src.B).release();
 }
 
 template <>
@@ -193,7 +193,7 @@ handle decode_str(const std::string& src) noexcept (false) {
     if (PyErr_WarnEx(PyExc_UnicodeWarning, msg.c_str(), 1) == -1)
         throw py::error_already_set();
 
-    return pysrc.inc_ref();
+    return pysrc.release();
 }
 
 }

--- a/python/docs/dlisio.rst
+++ b/python/docs/dlisio.rst
@@ -2,6 +2,8 @@ Open and Load
 =============
 .. autofunction:: dlisio.load
 .. autofunction:: dlisio.open
+.. autofunction:: dlisio.set_encodings
+.. autofunction:: dlisio.get_encodings
 
 Logical files
 =============

--- a/python/docs/intro.rst
+++ b/python/docs/intro.rst
@@ -88,6 +88,10 @@ This enables quick and easy mathematical operations on the data you care about.
 
 Please refer to :py:class:`dlisio.plumbing.Channel` and :py:class:`dlisio.plumbing.Frame`
 
+Strings and encodings
+=====================
+See :func:`dlisio.set_encodings`.
+
 .. [1] API RP66 v1, http://w3.energistics.org/RP66/V1/Toc/main.html
 .. [2] POSC, https://www.energistics.org/
 .. [3] Numpy, structured arrays, https://docs.scipy.org/doc/numpy-1.16.0/user/basics.rec.html

--- a/python/tests/test_semantics.py
+++ b/python/tests/test_semantics.py
@@ -96,7 +96,6 @@ def test_channel(f):
     assert channel.long_name              == longname
     assert channel.properties             == ["AVERAGED", "DERIVED", "PATCHED"]
     assert channel.reprc                  == 16
-    assert channel.units                  == "custom unit°"
     assert channel.dimension              == [4, 3, 2]
     assert channel.attic["DIMENSION"]     == [2, 3, 4]
     assert channel.axis                   == [axis3, axis2, axis1]
@@ -108,6 +107,27 @@ def test_channel(f):
     assert channel.source                 == tool
 
     _ = channel.describe(indent='   ', width=70, exclude='e')
+
+def test_string_encoding_warns(fpath):
+    prev_encodings = dlisio.get_encodings()
+    try:
+        dlisio.set_encodings([])
+        with pytest.warns(UnicodeWarning):
+            with dlisio.load(fpath) as (f, *_):
+                channel = f.object('CHANNEL', 'CHANN1', 10, 0)
+                assert channel.units == b'custom unit\xb0'
+    finally:
+        dlisio.set_encodings(prev_encodings)
+
+def test_string_latin1_encoding_works(fpath):
+    prev_encodings = dlisio.get_encodings()
+    try:
+        dlisio.set_encodings(['latin1'])
+        with dlisio.load(fpath) as (f, *_):
+            channel = f.object('CHANNEL', 'CHANN1', 10, 0)
+            assert channel.units == "custom unit°"
+    finally:
+        dlisio.set_encodings(prev_encodings)
 
 def test_channel_fdata(f):
     channel = f.object('CHANNEL', 'CHANN1', 10, 0)


### PR DESCRIPTION
Add user-defined string decoding table

Strings in Python are UTF-8, and strings in DLIS [1] are supposed to be a
subset of ASCII, which is also valid UTF-8. However, a lot of file are
written with encoded strings. Previously this was handled by only
looking for the degree symbol from latin1 and replacing it with UTF-8
degree, but that's not a good strategy.

Now, ASCII (i.e. valid UTF-8) is still assumed, but users can provide a
table of encodings to try if it should fail with dlisio.set_encodings.

This means that this patch BREAKS on files where the degree symbol
(0xB0) was the only non-ascii character. This is unfortunate, but
overall healthy, because users must now explicitly say that an encoding
is fine, rather than our hacky guess. Some strings are valid in multiple
encodings, and it's a user responsibility to make sure the correct one
is picked.

There is no way to guess what encodings are acceptable, as there is
nowhere in the DLIS file where encoding can (according to spec) be
specified.

[1] IDENT, ASCII, and UNITS