### PR TITLE
Return mnemonic not Channel for frame/channel.index

### DIFF
--- a/python/dlisio/plumbing/channel.py
+++ b/python/dlisio/plumbing/channel.py
@@ -129,22 +129,6 @@ class Channel(BasicObject):
         return self['SOURCE']
 
     @property
-    def index(self):
-        """The Channel this Channel is indexed against, if any. See
-        :attr:`Frame.index_type` for definition of existing index channel.
-
-        Returns
-        -------
-
-        channel : Channel or None
-        """
-        msg = 'This channel is an index channel'
-        index = self.frame.index
-
-        if index == self: logging.info(msg)
-        return index
-
-    @property
     def dtype(self):
         """dtype
 

--- a/python/dlisio/plumbing/frame.py
+++ b/python/dlisio/plumbing/frame.py
@@ -143,28 +143,23 @@ class Frame(BasicObject):
 
     @property
     def index(self):
-        """The Channel that serves as an index for all other Channels in this
-        Frame.
-
-        Frames may or may not have an index Channel, see :attr:`index_type` for
-        definition of existing index channel.
+        """Mnemonic of the channel all channels in this Frame are indexed
+        against, if any. See :attr:`Frame.index_type` for definition of
+        existing index channel.
 
         Returns
         -------
-        channel : Channel or None
-        """
-        msg = 'There is no index channel, see help(frame.index) for more info'
-        index = None
 
-        if self.index_type is None:
-            logging.warning(msg)
+        mnemonic : str
+        """
+        msg = 'Frame has no channels'
+        index = None
+        if len(self.channels) == 0:
+            logging.info(msg)
             return index
 
-        try:
-            index = self.channels[0]
-        except IndexError:
-            logging.warning(msg)
-
+        if self.index_type is None: index = 'FRAMENO'
+        else:                       index = self.channels[0].name
         return index
 
     @property
@@ -396,19 +391,8 @@ class Frame(BasicObject):
         DataFrame
 
         >>> curves = frame.curves()
-        >>> if frame.index_type:
-        >>>     indexname  = curves.dtype.names[0]
-        >>>     curvenames = curves.dtype.names[1:]
-        >>>     pdcurves = pd.DataFrame(curves[list(curvenames)], index=curves[indexname])
-        >>>     pdcurves.index.name = indexname
-        >>> else:
-        >>>     pdcurves = pd.DataFrame(curves)
-
-        Let's walk through this. Firstly, check that *index_type* is not None,
-        if it is, there is no index channel to set. Secondly, note how the
-        curvenames are all stored in the array itself. Then all that is needed
-        is to extract the first name as index and let the rest be added to the
-        DataFrame as normal Channels.
+        >>> pdcurves = pd.DataFrame(curves, index=curves[f.index])
+        >>> pdcurves.index.name = f.index
         """
         return curves(self.logicalfile, self, self.dtype, "", self.fmtstr(), "")
 

--- a/python/docs/examples.rst
+++ b/python/docs/examples.rst
@@ -186,7 +186,7 @@ and/or sliced by samples:
 .. code-block:: python
 
     >>> curves = fr.curves()
-    >>> curves[['TDEP', 'TENS_SL']][0:5]
+    >>> curves[[fr.index, 'TENS_SL']][0:5]
     array([(16677259., 2233.), (16678259., 2237.), (16679259., 2211.),
            (16680259., 2193.), (16681259., 2213.)])
 

--- a/python/tests/test_frames.py
+++ b/python/tests/test_frames.py
@@ -263,27 +263,3 @@ def test_frame_nochannels_no_index(assert_info):
 
     assert frame.index == None
     assert_info('There is no index channel')
-
-def test_channel_index():
-    frame = makeframe()
-    frame.attic['INDEX-TYPE'] = ['DECREASING']
-
-    index   = frame.channels[0]
-    channel = frame.channels[1]
-
-    assert channel.index == index
-
-def test_channel_is_index(assert_info):
-    frame = makeframe()
-    frame.attic['INDEX-TYPE'] = ['DECREASING']
-    channel = frame.channels[0]
-
-    assert channel.index == channel
-    assert_info('This channel is an index channel')
-
-def test_channel_noindex(assert_info):
-    frame = makeframe()
-    channel = frame.channels[0]
-
-    assert channel.index is None
-    assert_info('There is no index channel')

--- a/python/tests/test_frames.py
+++ b/python/tests/test_frames.py
@@ -249,17 +249,15 @@ def test_frame_index():
     frame = makeframe()
     frame.attic['INDEX-TYPE'] = ['DECREASING']
 
-    assert frame.index == frame.channels[0]
+    assert frame.index == frame.channels[0].name
 
 def test_frame_noindex(assert_info):
     frame = makeframe()
-
-    assert frame.index is None
-    assert_info('There is no index channel')
+    assert frame.index == 'FRAMENO'
 
 def test_frame_nochannels_no_index(assert_info):
     frame = dlisio.plumbing.Frame()
     frame.attic['INDEX-TYPE'] = ['DECREASING']
 
-    assert frame.index == None
-    assert_info('There is no index channel')
+    assert frame.index is None
+    assert_info('Frame has no channels')


### PR DESCRIPTION
With FRAMENO integrated into the numpy.ndarray returned by .curves()
it's natural to return FRAMENO, not None, from .index if there is no
index Channel. However, FRAMENO is not a Channel object. To make the
index properties coherent with FRAMENO, Channel.index and Frame.index
now returns the channel mnemonic, rather than the full channel object.

This is a breaking change, and some workflows where the user works
directly with Channels and not through the Frame objects will be a bit
more cumbersome. However, index now works seamlessly with indexing the
.curves() array, e.g:

``` 
curves = frame.curves()
 curves[[frame.index, 'GR', 'ALH1']]
```

closes #199 