### PR TITLE
Fix a bug where match() yielded the same obj more than once

### DIFF
--- a/python/dlisio/__init__.py
+++ b/python/dlisio/__init__.py
@@ -456,7 +456,7 @@ class dlis(object):
         ctype    = compileregex(type)
         cpattern = compileregex(pattern)
 
-        types = [x for x in self.record_types if re.match(ctype, x)]
+        types = [x for x in set(self.record_types) if re.match(ctype, x)]
 
         for t in types:
             for obj in self[t].values():

--- a/python/tests/test_dlis.py
+++ b/python/tests/test_dlis.py
@@ -65,6 +65,9 @@ def g():
     g.indexedobjects["440-TYPE"][ch.fingerprint] = ch
 
     g.record_types = list(g.indexedobjects.keys())
+
+    # Simulate the occurance of multiple Channel sets
+    g.record_types.append('CHANNEL')
     return g
 
 def test_object(g):


### PR DESCRIPTION
The dlis class keeps track of the type of object_sets that are present
in the file. This list is being used by dlis.match to match on
object-type. Because this is a list, and not a set, match would search a
particular object-type multiple times if there where multiple
object_sets of that type.

`dlis.object()` was effected in the same way as it is powered by `dlis.match()`
