### PR TITLE
Reintroduce object-counts in dlis.describe()

### DIFF
--- a/python/dlisio/__init__.py
+++ b/python/dlisio/__init__.py
@@ -545,22 +545,20 @@ class dlis(object):
 
         plumbing.describe_dict(buf, d, width, indent)
 
-        known, unknown = [], []
+        known, unknown = {}, {}
+        for objtype in set(self.record_types):
+            if objtype == 'encrypted': continue
 
-        for seen in set(self.record_types):
-            if seen == 'encrypted': continue
-            if seen in self.types:
-                known.append(seen)
-            else:
-                unknown.append(seen)
+            if objtype in self.types: known[objtype]   = len(self[objtype])
+            else:                     unknown[objtype] = len(self[objtype])
 
         if known:
             plumbing.describe_header(buf, 'Known objects', width, indent, lvl=2)
-            [plumbing.describe_text(buf, x, width, indent) for x in known]
+            plumbing.describe_dict(buf, known, width, indent)
 
         if unknown:
-            plumbing.describe_header(buf, '\nUnknown objects', width, indent, lvl=2)
-            [plumbing.describe_text(buf, x, width, indent) for x in unknown]
+            plumbing.describe_header(buf, 'Unknown objects', width, indent, lvl=2)
+            plumbing.describe_dict(buf, unknown, width, indent)
 
         return plumbing.Summary(info=buf.getvalue())
 

--- a/python/docs/examples.rst
+++ b/python/docs/examples.rst
@@ -83,17 +83,17 @@ Or about a logical file:
 
     Known objects
     --
-    FILE-HEADER
-    ORIGIN
-    CALIBRATION-COEFFICIENT
-    CHANNEL
-    FRAME
+    FILE-HEADER             : 1
+    ORIGIN                  : 3
+    CALIBRATION-COEFFICIENT : 8
+    CHANNEL                 : 104
+    FRAME                   : 2
 
     Unknown objects
     --
-    440-CHANNEL
-    440-OP-CORE_TABLES
-    440-OP-CHANNEL
+    440-CHANNEL             : 93
+    440-OP-CORE_TABLES      : 17
+    440-OP-CHANNEL          : 101
 
 Accessing objects
 -----------------


### PR DESCRIPTION
Due to the just-in-time loading of objects introduced in [1], the
object-count for each object-type in dlis.describe() was removed as it
would in effect load every object in the file.

Seaming that this information is valuable it is re-introduced on the
grounds that its fair to assume that describe() is only called in the
context of exploring a single file, or a few files. Hence, we can
tolerate the performance hit.

[1] SHA: f5090cc67b1d12add8ca4dab44bd0278bcde01f9