### PR TITLE
Let appveyor badge track builds from master only

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis](https://img.shields.io/travis/equinor/dlisio/master.svg?label=travis)](https://travis-ci.org/equinor/dlisio)
 [![CircleCI](https://circleci.com/gh/equinor/dlisio/tree/master.svg?style=svg)](https://circleci.com/gh/equinor/dlisio/tree/master)
-[![Appveyor](https://ci.appveyor.com/api/projects/status/jdhagpm7jkga07j1?svg=true)](https://ci.appveyor.com/project/jokva/dlisio)
+[![Appveyor](https://ci.appveyor.com/api/projects/status/jdhagpm7jkga07j1?svg=true)](https://ci.appveyor.com/project/jokva/dlisio/branch/master)
 [![PyPI version](https://badge.fury.io/py/dlisio.svg)](https://badge.fury.io/py/dlisio)
 
 ## Index ##


### PR DESCRIPTION
The appveyor badge returns the status of the last build of any branches
by default. We are only intereseted in the status of master really, what
goes on on different branches should not be reflected in the README.