### PR TITLE
Allow duplicated mnemonics in curves()

### DIFF
--- a/python/dlisio/plumbing/__init__.py
+++ b/python/dlisio/plumbing/__init__.py
@@ -3,7 +3,7 @@ from .axis import Axis
 from .fileheader import Fileheader
 from .longname import Longname
 from .origin import Origin
-from .frame import Frame
+from .frame import Frame, mkunique
 from .channel import Channel
 from .tool import Tool
 from .zone import Zone

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -340,7 +340,7 @@ def test_fmtstring(DWL206):
 
 def test_dtype(DWL206):
     frame2000 = DWL206.object('FRAME', '2000T', 2, 0)
-    dtype1 = frame2000.dtype
+    dtype1 = frame2000.dtype()
     assert dtype1 == np.dtype([('FRAMENO', np.int32),
                                ('TIME', np.float32),
                                ('TDEP', np.float32),


### PR DESCRIPTION
By default we allow duplicated mnemonics as long as Channels are
distinguishable by the triplet; mnemonic, origin, copynumber. If that is
not the case, its a clear standard violation and curves() throws.

Apparently there are files where this is the case, hence we supply the
option to read the curve-data anyway. The default-behavior of curves()
is still to throw if the standard is violated.