### PR TITLE
Set 'latin1' as default encoding in test suite

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -3,6 +3,8 @@ import logging
 
 import dlisio
 
+dlisio.set_encodings(['latin1'])
+
 @pytest.fixture(scope="module", name="DWL206")
 def DWL206():
     with dlisio.load('data/206_05a-_3_DWL_DWL_WIRE_258276498.DLIS') as (f,):

--- a/python/tests/test_parse.py
+++ b/python/tests/test_parse.py
@@ -604,10 +604,12 @@ def test_broken_utf8_value(tmpdir, merge):
         'data/chap3/objattr/broken-utf8-value.dlis.part',
     ]
     merge(path, content)
+
+    prev_encodings = dlisio.get_encodings()
+    dlisio.set_encodings([])
     with pytest.warns(UnicodeWarning):
         with dlisio.load(path) as (f, *_):
             f.load()
-    prev_encodings = dlisio.get_encodings()
     try:
         dlisio.set_encodings(['koi8_r'])
         with dlisio.load(path) as (f, *_):


### PR DESCRIPTION
One of our test-files include none-ascii characters. This pollutes the
test-output with a lot of UnicodeError's that we don't really care
about. Specifying the correct encoding cleans up the test-output.