### PR TITLE
Add preprocessor definitions for endianness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(dlisio LANGUAGES C CXX)
 include(CheckIncludeFile)
 include(CTest)
 include(GNUInstallDirs)
+include(TestBigEndian)
 
 option(BUILD_PYTHON "Build Python extension" ON)
 option(BUILD_DOC    "Build documentation"    OFF)
@@ -30,6 +31,8 @@ endif()
 add_custom_target(doc ALL)
 
 set(CMAKE_CXX_STANDARD 11)
+
+test_big_endian(BIG_ENDIAN)
 
 add_subdirectory(external/endianness)
 add_subdirectory(external/catch2)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -44,6 +44,11 @@ target_compile_options(dlisio-extension
     BEFORE
     PRIVATE $<$<CONFIG:Debug>:${warnings-c++}>
 )
+target_compile_definitions(dlisio
+    PRIVATE
+    $<$<BOOL:${BIG_ENDIAN}>:HOST_BIG_ENDIAN>
+    $<$<NOT:$<BOOL:${BIG_ENDIAN}>>:HOST_LITTLE_ENDIAN>
+)
 target_link_libraries(dlisio-extension
     PUBLIC dlisio
            mpark::variant


### PR DESCRIPTION
Test endianness with cmake's TestBigEndian and set preprocessor
definitions HOST_BIG_ENDIAN and HOST_LITTLE_ENDIAN. The missing
definition of HOST_BIG_ENDIAN was a bug, as we have code that assumes it
to be defined on big endian systems. This was never caught as we
currently do not test on any big endian machines.

Although not currently used, add HOST_LITTLE_ENDIAN for completeness.