### PR TITLE
Close unused handle in dlisio.load

### DIFF
--- a/python/dlisio/__init__.py
+++ b/python/dlisio/__init__.py
@@ -807,7 +807,9 @@ def load(path):
             stream = core.open(path)
             offset = core.findvrl(stream, hint)
         except RuntimeError:
-            if stream.eof(): break
+            if stream.eof():
+                stream.close()
+                break
             raise
 
     return Batch(lfs)

--- a/python/tests/test_loading.py
+++ b/python/tests/test_loading.py
@@ -9,6 +9,32 @@ import os
 
 import dlisio
 
+def test_filehandles_closed(tmpdir):
+    # Check that we don't leak open filehandles
+    #
+    # This test uses the fact that os.remove fails on windows if the file is in
+    # use as a proxy for testing that dlisio dont leak filehandles.  From the
+    # python docs [1]:
+    #
+    #   On Windows, attempting to remove a file that is in use causes an
+    #   exception to be raised; on Unix, the directory entry is removed but the
+    #   storage allocated to the file is not made available until the original
+    #   file is no longer in use.
+    #
+    # On linux on the other hand, os.remove does not fail even if there are
+    # open filehandles, hence this test only makes sence on Windows.
+    #
+    # [1] https://docs.python.org/3/library/os.html
+
+    # Copy the test file to a tmpdir in order to make this test reliable.
+    tmp = str(tmpdir.join('206_05a-_3_DWL_DWL_WIRE_258276498.DLIS'))
+    shutil.copyfile('data/206_05a-_3_DWL_DWL_WIRE_258276498.DLIS', tmp)
+
+    with dlisio.load(tmp) as _:
+        pass
+
+    os.remove(tmp)
+
 def test_context_manager():
     path = 'data/chap4-7/many-logical-files.dlis'
     f, *_ = dlisio.load(path)


### PR DESCRIPTION
There are no hints in the files to whether there are more logical files
to come. load therefore opens file handles for each logical file in a
loop until eof is hit. This last file handle is never used, nor where it
explicitly closed, causing load to leak it.