### PR TITLE
Don't build fmt tests and docs on CircleCI/Travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
             git clone https://github.com/fmtlib/fmt.git
             mkdir fmt/build
             cd fmt/build
-            cmake ..
+            cmake -DFMT_TEST=OFF -DFMT_DOC=OFF ..
             make
             <<#parameters.sudo >> sudo <</parameters.sudo >> make install
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_install:
     - git clone https://github.com/fmtlib/fmt.git
     - mkdir fmt/build
     - pushd fmt/build
-    - cmake ..
+    - cmake -DFMT_TEST=OFF -DFMT_DOC=OFF ..
     - make
     - sudo make install
     - popd

--- a/config.sh
+++ b/config.sh
@@ -17,7 +17,7 @@ function pre_build {
     if [ -z "$IS_OSX" ]; then
         pushd fmt/build;
         rm -rf *;
-        cmake ..;
+        cmake -DFMT_TEST=OFF -DFMT_DOC=OFF ..;
         make;
         make install;
         popd;


### PR DESCRIPTION
The need for building fmt from source on linux and macos is still here,
but we can at least slim down the build. There is no reason to build the
test or the docs, and skipping them drastically reduces build times.