### PR TITLE
Bigendian: circleci version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,6 +378,59 @@ jobs:
 #             # should be defined as CirceCI project environment variables
 #             twine upload --skip-existing dist/*
 
+  bigendian:
+    machine:
+      image: ubuntu-1604:201903-01 #is docker 18.09, so should contain buildKit
+    resource_class: large
+    parameters:
+      setup_image_path:
+        type: string
+        default: ~/project/artifacts/dlisio_bigendian_setup.tar
+      setup_image_name:
+        type: string
+        default: ci_dlisio_bigendian_setup
+    steps:
+      - checkout
+      - pull_submodules
+      - run:
+          name: Setup
+          command: |
+            mkdir -p "$(dirname << parameters.setup_image_path >>)"
+            # the core functionality allowing us to build on whatever architecture
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - restore_cache:
+          key: vers2-setup-image-{{ checksum "~/project/.circleci/images/setup/Dockerfile" }}
+      - run:
+          name: Assure setup image loaded locally
+          command: |
+            if [ ! -f << parameters.setup_image_path >> ]; then
+               echo "Local docker setup image not found. Recreating"
+               export DOCKER_BUILDKIT=1
+               docker build \
+                   -t << parameters.setup_image_name >> \
+                   -f ~/project/.circleci/images/setup/Dockerfile \
+                   --progress plain \
+                   .
+               docker save << parameters.setup_image_name >> > << parameters.setup_image_path >>
+            else
+               echo "Local docker setup image found. Loading"
+               docker load -i << parameters.setup_image_path >>
+            fi
+      - save_cache:
+          key: vers2-setup-image-{{ checksum "~/project/.circleci/images/setup/Dockerfile" }}
+          paths:
+            << parameters.setup_image_path >>
+      - run:
+          name: Build dlisio and run tests
+          command: |
+            export DOCKER_BUILDKIT=1
+            docker build \
+                -t dlisio \
+                -f ~/project/.circleci/images/build/Dockerfile \
+                --progress plain \
+                --build-arg image=<< parameters.setup_image_name >> \
+                .
+
 workflows:
   version: 2
   build:
@@ -423,3 +476,6 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+  arch:
+    jobs:
+      - bigendian

--- a/.circleci/images/build/Dockerfile
+++ b/.circleci/images/build/Dockerfile
@@ -1,0 +1,18 @@
+ARG image
+FROM $image
+
+#lfp
+WORKDIR /home/ci
+RUN git clone https://github.com/equinor/layered-file-protocols.git
+WORKDIR /home/ci/layered-file-protocols/build
+RUN cmake -DBUILD_SHARED_LIBS=ON -DLFP_FMT_HEADER_ONLY=ON -DCMAKE_INSTALL_NAME_DIR=/usr/local/lib -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ..
+RUN make -j4
+RUN make install
+
+#dlisio
+WORKDIR /home/ci
+COPY . /home/ci/dlisio
+WORKDIR /home/ci/dlisio/build
+RUN cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_NAME_DIR=/usr/local/lib -DPYTHON_EXECUTABLE=`which python3` ..
+RUN make -j4
+RUN ctest --output-on-failure

--- a/.circleci/images/setup/Dockerfile
+++ b/.circleci/images/setup/Dockerfile
@@ -1,0 +1,17 @@
+FROM s390x/debian
+RUN apt-get update
+RUN apt-get install -y cmake g++ python3 python3-pip git
+
+#fmt
+WORKDIR /home/ci
+RUN git clone https://github.com/fmtlib/fmt.git
+WORKDIR /home/ci/fmt/build
+RUN cmake -DFMT_TEST=OFF -DFMT_DOC=OFF ..
+RUN make -j4
+RUN make install
+
+#dlisio_requirements
+WORKDIR /home/ci
+COPY . /home/ci/dlisio_requirements
+WORKDIR /home/ci/dlisio_requirements
+RUN python3 -m pip install --user -r python/requirements-dev.txt


### PR DESCRIPTION
When deciding which CI to use for bigendian check the following criteria were considered:
1. On travis we are able to build on native machines, on CircleCi - only with the help of qemu.
2. CircleCI build time is very long, especially if docker images are not stored and maintained. Travis is way faster.
3. Travis multi-architecture solution didn't seem to be very stable.

Travis won.

But now it seems like Travis bigendian job fails more often than it passes (due to reasons independent from dlisio).
Hence adding CircleCI solution, given that it was actually implemented already.
We shall see which of the jobs frustrates us less.