### PR TITLE
Fix vsingl and vsinglo VAX conversions

### DIFF
--- a/lib/test/pack.cpp
+++ b/lib/test/pack.cpp
@@ -221,7 +221,7 @@ TEST_CASE_METHOD(check_packsize, "pack floats", "[pack]") {
         0xC3, 0x19, 0x00, 0x00, //-153 fsingl
         0xC1, 0xC0, 0x00, 0x00, //-12 isingl
         0x45, 0x10, 0x00, 0x08, //65536.5 isingl
-        0xAA, 0xC2, 0x00, 0x00, //-26.5 vsingl
+        0xAA, 0xC2, 0x00, 0x00, //-21.25 vsingl
         0x00, 0x3F, 0x00, 0x00, //0.125 vsingl
     };
 
@@ -238,7 +238,7 @@ TEST_CASE_METHOD(check_packsize, "pack floats", "[pack]") {
     CHECK( dst[ 3 ] == -153.0 );
     CHECK( dst[ 4 ] == -12 );
     CHECK( dst[ 5 ] == 65536.5 );
-    CHECK( dst[ 6 ] == -26.5 );
+    CHECK( dst[ 6 ] == -21.25 );
     CHECK( dst[ 7 ] == 0.125 );
 }
 

--- a/python/tests/test_curves_reprcodes.py
+++ b/python/tests/test_curves_reprcodes.py
@@ -205,7 +205,7 @@ def test_vsingl_x2():
     fpath = 'data/chap4-7/iflr/reprcodes-x2/06-vsingl.dlis'
     curves = load_curves(fpath)
     assert curves[0][1] == 0.125
-    assert curves[1][1] == -26.5
+    assert curves[1][1] == -21.25
 
 def test_fdoubl_x2():
     fpath = 'data/chap4-7/iflr/reprcodes-x2/07-fdoubl.dlis'


### PR DESCRIPTION
Our VAX F_Floating to IEEE754 floating point conversion and visa versa
was buggy. In vsingl (from vax to ieee) the calculation of the mantissa
did not account for the implicit/hidden 24th bit of the mantissa [1].

The test-suite is updated and augmented with test-data from libwaxdata

[1] https://pubs.usgs.gov/of/2005/1424/of2005-1424_v1.2.pdf
[2] https://pubs.usgs.gov/of/2005/1424/