### PR TITLE
1rst draft for retrieving parameters unit

### DIFF
--- a/python/dlisio/ext/core.cpp
+++ b/python/dlisio/ext/core.cpp
@@ -849,6 +849,11 @@ PYBIND11_MODULE(core, m) {
         })
     ;
 
+    py::class_< dl::object_attribute >( m, "object_attribute" )
+        .def_readonly("values", &dl::object_attribute::value)
+        .def_readonly("units", &dl::object_attribute::units)
+    ;
+
     py::class_< dl::basic_object >( m, "basic_object" )
         .def_readonly("type", &dl::basic_object::type)
         .def_readonly("name", &dl::basic_object::object_name)
@@ -858,7 +863,7 @@ PYBIND11_MODULE(core, m) {
         .def( "__eq__", &dl::basic_object::operator == )
         .def( "__ne__", &dl::basic_object::operator != )
         .def( "__getitem__", []( dl::basic_object& o, const std::string& key ) {
-            try { return o.at(key).value; }
+            try { return o.at(key); }
             catch (const std::out_of_range& e) { throw py::key_error( e.what() ); }
         })
         .def( "__repr__", []( const dl::basic_object& o ) {

--- a/python/dlisio/plumbing/basicobject.py
+++ b/python/dlisio/plumbing/basicobject.py
@@ -206,7 +206,7 @@ class BasicObject():
             parse_as = vector
 
         try:
-            rp66value = self.attic[key]
+            rp66value = self.attic[key].values
         except KeyError:
             return defaultvalue(parse_as)
 
@@ -259,7 +259,7 @@ class BasicObject():
             all attributes not defined in :attr:`attributes`
         """
         stash = {
-            key : self.attic[key]
+            key : self.attic[key].values
             for key
             in self.attic.keys()
             if key not in self.attributes

--- a/python/dlisio/plumbing/computation.py
+++ b/python/dlisio/plumbing/computation.py
@@ -147,7 +147,7 @@ class Computation(BasicObject):
         Zone('ZONE-A')
         """
         try:
-            values = self.attic['VALUES']
+            values = self.attic['VALUES'].values
         except KeyError:
             return np.empty(0)
 

--- a/python/dlisio/plumbing/group.py
+++ b/python/dlisio/plumbing/group.py
@@ -63,7 +63,7 @@ class Group(BasicObject):
     @property
     def objects(self):
         try:
-            ref = self.attic['OBJECT-LIST'][0]
+            ref = self.attic['OBJECT-LIST'].values[0]
         except (KeyError, IndexError):
             return []
 

--- a/python/dlisio/plumbing/measurement.py
+++ b/python/dlisio/plumbing/measurement.py
@@ -127,7 +127,7 @@ class Measurement(BasicObject):
         may be either a scalar or ndarray
         """
         try:
-            samples = self.attic['MEASUREMENT']
+            samples = self.attic['MEASUREMENT'].values
         except KeyError:
             return np.empty(0)
 
@@ -147,7 +147,7 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            dev = self.attic['MAXIMUM-DEVIATION']
+            dev = self.attic['MAXIMUM-DEVIATION'].values
         except KeyError:
             return np.empty(0)
 
@@ -166,7 +166,7 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            dev = self.attic['STANDARD-DEVIATION']
+            dev = self.attic['STANDARD-DEVIATION'].values
         except KeyError:
             return np.empty(0)
 
@@ -181,7 +181,7 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            ref = self.attic['REFERENCE']
+            ref = self.attic['REFERENCE'].values
         except KeyError:
             return np.empty(0)
 
@@ -199,7 +199,7 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            tolerance = self.attic['PLUS-TOLERANCE']
+            tolerance = self.attic['PLUS-TOLERANCE'].values
         except KeyError:
             return np.empty(0)
 
@@ -217,7 +217,7 @@ class Measurement(BasicObject):
         structure as the samples in the sample attribute.
         """
         try:
-            tolerance   = self.attic['MINUS-TOLERANCE']
+            tolerance   = self.attic['MINUS-TOLERANCE'].values
         except KeyError:
             return np.empty(0)
 

--- a/python/dlisio/plumbing/parameter.py
+++ b/python/dlisio/plumbing/parameter.py
@@ -82,6 +82,10 @@ class Parameter(BasicObject):
         return self['ZONES']
 
     @property
+    def unit(self):
+        return self.attic['VALUES'].units
+
+    @property
     def values(self):
         """ Parameter values
 
@@ -127,7 +131,7 @@ class Parameter(BasicObject):
         Zone('ZONE-A')
         """
         try:
-            values = self.attic['VALUES']
+            values = self.attic['VALUES'].values
         except KeyError:
             return np.empty(0)
 

--- a/python/dlisio/plumbing/wellref.py
+++ b/python/dlisio/plumbing/wellref.py
@@ -95,12 +95,12 @@ class Wellref(BasicObject):
 
         for i in range(1, 4):
             try:
-                key = self.attic[name.format(i)][0]
+                key = self.attic[name.format(i)].values[0]
             except KeyError:
                 key = custom_label.format(i)
 
             try:
-                val = self.attic[value.format(i)][0]
+                val = self.attic[value.format(i)].values[0]
             except KeyError:
                 val = None
 

--- a/python/tests/test_basic_object.py
+++ b/python/tests/test_basic_object.py
@@ -5,6 +5,7 @@ import pytest
 import dlisio
 from dlisio.plumbing import *
 
+from collections import namedtuple
 
 def test_getitem(f):
     obj = f.object('FRAME', 'FRAME1')
@@ -111,9 +112,10 @@ def test_parse_attribute_reverse_unexpected_element(assert_log):
 
 def test_valuetype_mismatch(assert_log):
     tool = dlisio.plumbing.tool.Tool()
+    Attr = namedtuple('attr', ['values', 'units'], defaults=[[], None])
     tool.attic = {
-        'DESCRIPTION' : ["Description", "Unexpected description"],
-        'STATUS'      : ["Yes", 0],
+        'DESCRIPTION' : Attr(["Description", "Unexpected description"]),
+        'STATUS'      : Attr(["Yes", 0])
     }
 
     assert tool.description == "Description"

--- a/python/tests/test_describe.py
+++ b/python/tests/test_describe.py
@@ -130,9 +130,12 @@ def test_describe_header():
 
 def test_describe_description():
     ln = Longname()
+    from collections import namedtuple
+    Attr = namedtuple('attr', ['values', 'units'], defaults=[[], None])
+
     ln.attic = {
-        'QUANTITY'           : ['diameter and stuff'],
-        'SOURCE-PART-NUMBER' : [10]
+        'QUANTITY'           : Attr(['diameter and stuff']),
+        'SOURCE-PART-NUMBER' : Attr([10])
     }
     # description is a Longname object
     case1 = (' Description\n'

--- a/python/tests/test_encodings.py
+++ b/python/tests/test_encodings.py
@@ -52,7 +52,7 @@ def test_broken_utf8_value(tmpdir, merge_files_oneLR):
         dlisio.set_encodings(['koi8_r'])
         with dlisio.load(path) as (f, *_):
             obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-            assert obj.attic['DEFAULT_ATTRIBUTE'] == ['ВАЖНЫЙ-ПАРАМЕТР']
+            assert obj.attic['DEFAULT_ATTRIBUTE'].values == ['ВАЖНЫЙ-ПАРАМЕТР']
             assert obj.stash['DEFAULT_ATTRIBUTE'] == ['ВАЖНЫЙ-ПАРАМЕТР']
             #assert units == "2 локтя на долю"
     finally:

--- a/python/tests/test_logical_record.py
+++ b/python/tests/test_logical_record.py
@@ -22,7 +22,7 @@ def test_default_attribute(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['DEFAULT_ATTRIBUTE']
+        attr = obj.attic['DEFAULT_ATTRIBUTE'].values
         #assert attr.count == 2
         #assert attr.reprc == dlisio.core.reprc.fdoubl
         #assert attr.units == 'default attr units'
@@ -41,8 +41,8 @@ def test_default_attribute_cut(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        assert obj.attic['INVARIANT_ATTRIBUTE']
-        assert obj.attic['DEFAULT_ATTRIBUTE']
+        assert obj.attic['INVARIANT_ATTRIBUTE'].values
+        assert obj.attic['DEFAULT_ATTRIBUTE'].values
 
 @pytest.mark.future_test_attributes
 def test_invariant_attribute(tmpdir, merge_files_oneLR):
@@ -56,7 +56,7 @@ def test_invariant_attribute(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['INVARIANT_ATTRIBUTE']
+        attr = obj.attic['INVARIANT_ATTRIBUTE'].values
         #assert attr.count == 3
         #assert attr.reprc == dlisio.core.reprc.status
         #assert attr.units == 'invariant units'
@@ -76,7 +76,7 @@ def test_invariant_attribute_in_object(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['DEFAULT_ATTRIBUTE']
+        attr = obj.attic['DEFAULT_ATTRIBUTE'].values
         assert attr == [8.0]
 
 
@@ -93,9 +93,9 @@ def test_absent_attribute(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        assert obj.attic['INVARIANT_ATTRIBUTE']
+        assert obj.attic['INVARIANT_ATTRIBUTE'].values
         with pytest.raises(KeyError):
-            _ = obj.attic['DEFAULT_ATTRIBUTE']
+            _ = obj.attic['DEFAULT_ATTRIBUTE'].values
 
 
 @pytest.mark.future_warning_absent_attr_in_template
@@ -111,7 +111,7 @@ def test_absent_attribute_in_template(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        assert obj.attic['DEFAULT_ATTRIBUTE']
+        assert obj.attic['DEFAULT_ATTRIBUTE'].values
 
 @pytest.mark.future_test_attributes
 def test_global_default_attribute(tmpdir, merge_files_oneLR):
@@ -126,7 +126,7 @@ def test_global_default_attribute(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['GLOBAL_DEFAULT_ATTRIBUTE']
+        attr = obj.attic['GLOBAL_DEFAULT_ATTRIBUTE'].values
         #assert attr.count == 1
         #assert attr.reprc == dlisio.core.reprc.ident
         #assert attr.units == ''
@@ -146,7 +146,7 @@ def test_all_attribute_bits(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['DEFAULT_ATTRIBUTE']
+        attr = obj.attic['DEFAULT_ATTRIBUTE'].values
         #assert attr.count == 4
         #assert attr.reprc == dlisio.core.reprc.ushort
         #assert attr.units == 'overwritten units'
@@ -165,7 +165,7 @@ def test_objattr_same_as_default_no_value(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['DEFAULT_ATTRIBUTE']
+        attr = obj.attic['DEFAULT_ATTRIBUTE'].values
         assert attr == [-0.75, 10.0]
 
 
@@ -231,7 +231,7 @@ def test_repcode(tmpdir, merge_files_oneLR, filename_p, attr_n, attr_reprc, attr
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic[attr_n]
+        attr = obj.attic[attr_n].values
         #assert attr.reprc == attr_reprc
         assert attr == [attr_v]
 
@@ -282,7 +282,7 @@ def test_repcode_invalid_in_template_no_value(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *_):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['INVALID']
+        attr = obj.attic['INVALID'].values
         assert attr == [1, 2, 3, 4]
 
 
@@ -314,7 +314,7 @@ def test_repcode_different_no_value(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *_):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        assert obj.attic['DEFAULT_ATTRIBUTE'] == [0j, 0j]
+        assert obj.attic['DEFAULT_ATTRIBUTE'].values == [0j, 0j]
 
 @pytest.mark.future_test_attributes
 def test_count0_novalue(tmpdir, merge_files_oneLR):
@@ -329,7 +329,7 @@ def test_count0_novalue(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['DEFAULT_ATTRIBUTE']
+        attr = obj.attic['DEFAULT_ATTRIBUTE'].values
         #assert attr.count == 0
         assert attr == None
 
@@ -347,7 +347,7 @@ def test_count0_value_bit(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['DEFAULT_ATTRIBUTE']
+        attr = obj.attic['DEFAULT_ATTRIBUTE'].values
         #assert attr.count == 0
         assert attr == None
 
@@ -365,7 +365,7 @@ def test_count0_different_repcode(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['DEFAULT_ATTRIBUTE']
+        attr = obj.attic['DEFAULT_ATTRIBUTE'].values
         #assert attr.count == 0
         #assert attr.reprc == dlisio.core.reprc.units
         assert attr == None
@@ -384,7 +384,7 @@ def test_label_bit_set_in_attribute(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        assert obj.attic['DEFAULT_ATTRIBUTE']
+        assert obj.attic['DEFAULT_ATTRIBUTE'].values
 
 
 @pytest.mark.future_warning_label_bit_not_set_in_template
@@ -400,7 +400,7 @@ def test_label_bit_not_set_in_template(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['NEW_ATTRIBUTE']
+        attr = obj.attic['NEW_ATTRIBUTE'].values
         dt = datetime(2033, 4, 19, 20, 39, 58, 103000)
         assert attr == [dt]
 
@@ -418,7 +418,7 @@ def test_set_type_bit_not_set_in_set(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        assert obj.attic['DEFAULT_ATTRIBUTE']
+        assert obj.attic['DEFAULT_ATTRIBUTE'].values
 
 
 @pytest.mark.future_warning_object_name_bit_not_set
@@ -433,7 +433,7 @@ def test_object_name_bit_not_set_in_object(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        assert obj.attic['DEFAULT_ATTRIBUTE']
+        assert obj.attic['DEFAULT_ATTRIBUTE'].values
 
 
 @pytest.mark.future_test_attributes
@@ -449,7 +449,7 @@ def test_novalue_less_count(tmpdir, merge_files_oneLR):
 
     with dlisio.load(path) as (f, *tail):
         obj = f.object('VERY_MUCH_TESTY_SET', 'OBJECT', 1, 1)
-        attr = obj.attic['DEFAULT_ATTRIBUTE']
+        attr = obj.attic['DEFAULT_ATTRIBUTE'].values
         #assert attr.count == 1
         #assert attr.reprc == dlisio.core.reprc.fdoubl
         #assert attr.units == 'default attr units'

--- a/python/tests/test_monkey_patching.py
+++ b/python/tests/test_monkey_patching.py
@@ -10,6 +10,9 @@ from dlisio.plumbing import Parameter
 
 import dlisio
 
+from collections import namedtuple
+Attr = namedtuple('attr', ['values', 'units'], defaults=[[], None])
+
 class ActuallyKnown(dlisio.plumbing.basicobject.BasicObject):
     attributes = {
         "SOME_LIST"   : valuetypes.vector,
@@ -104,10 +107,10 @@ def test_type_removal(f):
 
 def test_attribute_change_in_instance():
     ch1 = Channel()
-    ch1.attic['PROPERTIES'] = [10]
+    ch1.attic['PROPERTIES'] = Attr([10])
 
     ch2 = Channel()
-    ch2.attic['PROPERTIES'] = [10]
+    ch2.attic['PROPERTIES'] = Attr([10])
 
     # Change properties to be parsed as scalar (not vector)
     ch1.attributes = dict(ch1.attributes)
@@ -120,10 +123,10 @@ def test_attribute_change_in_instance():
 
 def test_attribute_change_in_class():
     ch1 = Channel()
-    ch1.attic['PROPERTIES'] = [10]
+    ch1.attic['PROPERTIES'] = Attr([10])
 
     ch2 = Channel()
-    ch2.attic['PROPERTIES'] = [10]
+    ch2.attic['PROPERTIES'] = Attr([10])
 
     try:
         # Change properties to be parsed as scalar (not vector)

--- a/python/tests/test_object_structures.py
+++ b/python/tests/test_object_structures.py
@@ -87,13 +87,13 @@ def test_channel(f):
     assert channel.properties             == ["AVERAGED", "DERIVED", "PATCHED"]
     assert channel.reprc                  == 16
     assert channel.dimension              == [4, 3, 2]
-    assert channel.attic["DIMENSION"]     == [2, 3, 4]
+    assert channel.attic["DIMENSION"].values     == [2, 3, 4]
     assert channel.axis                   == [axis3, axis2, axis1]
-    assert channel.attic["AXIS"]          == [(10, 0, 'AXIS1'),
+    assert channel.attic["AXIS"].values          == [(10, 0, 'AXIS1'),
                                               (10, 0, 'AXIS2'),
                                               (10, 0, 'AXIS3')]
     assert channel.element_limit          == [11, 15, 10]
-    assert channel.attic["ELEMENT-LIMIT"] == [10, 15, 11]
+    assert channel.attic["ELEMENT-LIMIT"].values == [10, 15, 11]
     assert channel.source                 == tool
 
 def test_frame(f):
@@ -139,11 +139,11 @@ def test_parameter(f):
 
     assert p.long_name           == longname
     assert p.dimension           == [2, 3]
-    assert p.attic["DIMENSION"]  == [3, 2]
+    assert p.attic["DIMENSION"].values  == [3, 2]
     assert p.axis                == [axis3, axis2]
-    assert len(p.attic["AXIS"])  == 2
+    assert len(p.attic["AXIS"].values)  == 2
     assert p.zones               == [zoneA, None, None, None]
-    assert len(p.attic["ZONES"]) == 4
+    assert len(p.attic["ZONES"].values) == 4
 
     sample = np.reshape(np.array([1, 2, 3, 4, 5, 6]), (2,3))
 
@@ -196,7 +196,7 @@ def test_tool(f):
     assert tool.status                   == True
     assert tool.channels                 == [channel1, channel2]
     assert tool.parameters               == [param1, None, param2]
-    assert len(tool.attic['PARAMETERS']) == 3
+    assert len(tool.attic['PARAMETERS'].values) == 3
 
 def test_message(f):
     mes = f.object('MESSAGE', 'MESSAGE1', 10, 0)
@@ -219,7 +219,7 @@ def test_measurement(f):
     assert m.source             == tool
     assert m.mtype              == "Zero"
     assert m.dimension          == [3, 2]
-    assert m.attic["DIMENSION"] == [2, 3]
+    assert m.attic["DIMENSION"].values == [2, 3]
     assert m.axis               == [axis2, axis1]
     assert m.samplecount        == 4
     assert m.begin_time         == 13447
@@ -280,7 +280,7 @@ def test_computation(f):
     assert com.long_name          == 'computation object 2'
     assert com.properties         == ['MUDCAKE-CORRECTED', 'DEPTH-MATCHED']
     assert com.dimension          == [4, 2]
-    assert com.attic["DIMENSION"] == [2, 4]
+    assert com.attic["DIMENSION"].values == [2, 4]
     assert com.axis               == [axis3, axis2]
     assert com.zones              == [zone]
     assert com.source             == process
@@ -296,17 +296,17 @@ def test_splice(f):
 
     # Output channel does not exist, but should be accessible through attic
     assert splice.output_channel == None
-    assert splice.attic['OUTPUT-CHANNEL'][0].id         == 'CHANN-NEW'
-    assert splice.attic['OUTPUT-CHANNEL'][0].origin     == 10
-    assert splice.attic['OUTPUT-CHANNEL'][0].copynumber ==  0
+    assert splice.attic['OUTPUT-CHANNEL'].values[0].id         == 'CHANN-NEW'
+    assert splice.attic['OUTPUT-CHANNEL'].values[0].origin     == 10
+    assert splice.attic['OUTPUT-CHANNEL'].values[0].copynumber ==  0
 
     assert splice.input_channels == [in1, in2]
 
     # Second zone does not exist, but should be accessible through attic
     assert splice.zones                       == [zone1 , None]
-    assert splice.attic['ZONES'][1].id         == 'ZONE-B'
-    assert splice.attic['ZONES'][1].origin     == 10
-    assert splice.attic['ZONES'][1].copynumber == 0
+    assert splice.attic['ZONES'].values[1].id         == 'ZONE-B'
+    assert splice.attic['ZONES'].values[1].origin     == 10
+    assert splice.attic['ZONES'].values[1].copynumber == 0
 
 def test_wellref(f):
     wellref = f.object('WELL-REFERENCE', 'THE-WELL', 10, 0)
@@ -322,14 +322,17 @@ def test_wellref(f):
     assert wellref.coordinates['elevation']  == 0.25
 
 def test_wellref_coordinates():
+    from collections import namedtuple
+    Attr = namedtuple('attr', ['values', 'units'], defaults=[[], None])
+
     wellref = dlisio.plumbing.wellref.Wellref()
     wellref.attic = {
-        'COORDINATE-2-VALUE' : [2],
-        'COORDINATE-1-NAME'  : ['longitude'],
-        'COORDINATE-3-NAME'  : ['elevation'],
-        'COORDINATE-1-VALUE' : [1],
-        'COORDINATE-3-VALUE' : [3],
-        'COORDINATE-2-NAME'  : ['latitude'],
+        'COORDINATE-2-VALUE' : Attr([2]),
+        'COORDINATE-1-NAME'  : Attr(['longitude']),
+        'COORDINATE-3-NAME'  : Attr(['elevation']),
+        'COORDINATE-1-VALUE' : Attr([1]),
+        'COORDINATE-3-VALUE' : Attr([3]),
+        'COORDINATE-2-NAME'  : Attr(['latitude']),
     }
 
     assert wellref.coordinates['longitude']  == 1


### PR DESCRIPTION
I'm just sharing the code that I'm currently using to retrieve the units of the parameters.
Just in case it could help. It's at draft state, but working well for me.

In this approach, the \_\_getitem__ of basic_object returns an object_attribute object with unit and values instead of the values alone.