### PR TITLE
Remove unknown sphinx directive autoinstanceattribute

### DIFF
--- a/python/docs/dlisio.rst
+++ b/python/docs/dlisio.rst
@@ -21,7 +21,7 @@ Logical files
     :member-order: bysource
     :undoc-members:
 
-    .. autoinstanceattribute:: types
+    .. autoattribute:: types
         :annotation: = {}
 
 .. currentmodule:: dlisio.plumbing


### PR DESCRIPTION
The autoinstanceattribute directive is not part of newer sphinx
versions. It's use was also incorrect in the first place as it did not
render the docstring of the attribute. Using autoattribute fixes that.