### PR TITLE
Ensure appveyor uses the latest pip version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ complete overview of changes, please refer to the git log.
 The format is based on `Keep a Changelog`_,
 but most notably, without sectioning changes into type-of-change.
 
+0.3.1_ - 2020.03.10
+-------------------
+* Solves an issue in the Windows deploy pipeline on Appveyor that resulted in
+  the pipeline failing to upload the python wheels to PyPi.
+
 0.3.0_ - 2020.03.09
 -------------------
 * Added an initial pass at a Log Information Standard 79 (LIS79) reader. Like
@@ -212,6 +217,7 @@ but most notably, without sectioning changes into type-of-change.
 .. _`Keep a changelog`: https://keepachangelog.com/en/1.0.0/
 .. _readthedocs: https://dlisio.readthedocs.io/en/stable/
 
+.. _0.3.1: https://github.com/equinor/dlisio/compare/v0.3.0...v0.3.1
 .. _0.3.0: https://github.com/equinor/dlisio/compare/v0.2.6...v0.3.0
 .. _0.2.6: https://github.com/equinor/dlisio/compare/v0.2.5...v0.2.6
 .. _0.2.5: https://github.com/equinor/dlisio/compare/v0.2.4...v0.2.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ matrix:
 install:
     - IF DEFINED PYTHON (IF "%platform%" == "x64" SET PYTHON=%PYTHON%-x64)
     - IF DEFINED PYTHON SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+    - IF DEFINED PYTHON pip install --upgrade pip --user
     - IF DEFINED PYTHON pip install --upgrade
         twine
         wheel


### PR DESCRIPTION
This commit solves a dependency issue between twine and
importlib-metadata which resulted in our deploy-pipeline on Appveyor to
fail [1].

Essentially whats going on is that pip finds an already installed,
older version (v3.4.0) of importlib-metadata when installing twine. The
dependency resolver in pip, prior to version 20.3, ignores twine's
minmum-requirement for importlib-metadata (v3.6.0) and keeps the old
version, as can be seen from the logs of the failing build:
```
        $ IF DEFINED PYTHON pip install --upgrade twine wheel
        ...
        Requirement already satisfied, skipping upgrade:
        importlib-metadata; python_version < "3.8" in
        c:\python36\lib\site-packages (from twine) (3.4.0)
        ...
```
This to-old importlib-metadata version causes twine to fail when we
later try to upload the wheels to pypi. In version 20.3 pip got a new
dependency resolver, that does _not_ ignore the twine requirements and
_do_ upgrade the importlib-metadata version when installing twine.

[1] https://github.com/pypa/twine/issues/729