### PR TITLE
Pin fmtlib version in CI pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ commands:
             git clone https://github.com/fmtlib/fmt.git
             mkdir fmt/build
             cd fmt/build
+            git checkout 7.1.3
             cmake -DFMT_TEST=OFF -DFMT_DOC=OFF ..
             make
             <<#parameters.sudo >> sudo <</parameters.sudo >> make install
@@ -299,6 +300,7 @@ jobs:
               git clone https://github.com/fmtlib/fmt.git
               mkdir fmt/build
               cd fmt/build
+              git checkout 7.1.3
               cmake -DFMT_TEST=OFF `
                     -DFMT_DOC=OFF `
                     -DCMAKE_BUILD_TYPE=Release `

--- a/.circleci/images/setup/Dockerfile
+++ b/.circleci/images/setup/Dockerfile
@@ -14,6 +14,7 @@ RUN make install
 WORKDIR /home/ci
 RUN git clone https://github.com/fmtlib/fmt.git
 WORKDIR /home/ci/fmt/build
+RUN git checkout 7.1.3
 RUN cmake -DFMT_TEST=OFF -DFMT_DOC=OFF ..
 RUN make -j4
 RUN make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ before_install:
     - git clone https://github.com/fmtlib/fmt.git
     - mkdir fmt/build
     - pushd fmt/build
+    - git checkout 7.1.3
     - cmake -DFMT_TEST=OFF -DFMT_DOC=OFF ..
     - make
     - sudo make install

--- a/.travis/bigendian/Dockerfile
+++ b/.travis/bigendian/Dockerfile
@@ -15,6 +15,7 @@ RUN make install
 WORKDIR /home/ci
 RUN git clone https://github.com/fmtlib/fmt.git
 WORKDIR /home/ci/fmt/build
+RUN git checkout 7.1.3
 RUN cmake -DFMT_TEST=OFF -DFMT_DOC=OFF ..
 RUN make -j4
 RUN make install

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To develop dlisio, or to build a particular revision from source, you need:
 * A C++11 compatible compiler (tested daily on gcc, clang, and msvc 2015)
 * [CMake](https://cmake.org/) version 3.5 or greater
 * [Python](https://python.org) version 3.6 or greater
-* [fmtlib](http://fmtlib.net/) tested mainly with 5.3.0
+* [fmtlib](http://fmtlib.net/) tested mainly with 7.3.1
 * [mpark_variant](https://github.com/mpark/variant)
 * [pybind11](https://github.com/pybind/pybind11) version 2.6 or greater
 * [setuptools](https://pypi.python.org/pypi/setuptools) version 28 or greater

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ before_build:
     - git clone https://github.com/fmtlib/fmt.git
     - ps: mkdir fmt/build
     - ps: pushd fmt/build
+    - git checkout 7.1.3
     - cmake -G %generator%
             -DFMT_TEST=OFF
             -DFMT_DOC=OFF ..


### PR DESCRIPTION
We keep running into issues when building fmtlib from source. To avoid
the hassle we switch to a stable version.