### PR TITLE
Document backdoor access to units

### DIFF
--- a/python/dlisio/dlis/axis.py
+++ b/python/dlisio/dlis/axis.py
@@ -17,11 +17,17 @@ class Axis(BasicObject):
     axis_id : str
         Axis identifier
 
+        RP66V1 name: *AXIS-ID*
+
     coordinates : list
         Explicit coordinate value along the axis
 
+        RP66V1 name: *COORDINATES*
+
     spacing
         Constant, signed spacing along the axis between successive coordinates
+
+        RP66V1 name: *SPACING*
 
     See also
     --------

--- a/python/dlisio/dlis/calibration.py
+++ b/python/dlisio/dlis/calibration.py
@@ -14,22 +14,34 @@ class Calibration(BasicObject):
     method : str
         Computational method used to calibrate the channels
 
+        RP66V1 name: *METHOD*
+
     calibrated : list(Channel)
         Calibrated channels
+
+        RP66V1 name: *CALIBRATED-CHANNELS*
 
     uncalibrated : list(Channel)
         Uncalibrated channels. I.e. the channels as they where before
         calibration
 
+        RP66V1 name: *UNCALIBRATED-CHANNELS*
+
     coefficients : list(Coefficient)
         Coefficients
+
+        RP66V1 name: *COEFFICIENTS*
 
     measurements : list(Measurement)
         Measurements
 
+        RP66V1 name: *MEASUREMENTS*
+
     parameters : list(Parameter)
         Parameters containing numerical and textual information assosiated
         with the calibration process.
+
+        RP66V1 name: *PARAMETERS*
 
     See also
     --------

--- a/python/dlisio/dlis/channel.py
+++ b/python/dlisio/dlis/channel.py
@@ -26,27 +26,43 @@ class Channel(BasicObject):
     long_name : str or Longname
         Descriptive name of the channel.
 
+        RP66V1 name: *LONG-NAME*
+
     reprc : int
         Representation code
 
+        RP66V1 name: *REPRESENTATION-CODE*
+
     units : str
         Physical units of each element in the channel's sample arrays
+
+        RP66V1 name: *UNITS*
 
     properties : list(str)
         Property indicators that summarizes the characteristics of the
         channel and the processing that have produced it.
 
+        RP66V1 name: *PROPERTIES*
+
     dimension : list(int)
         Dimensions of the samples
+
+        RP66V1 name: *DIMENSION*
 
     axis : list(Axis)
         Coordinate axes of the samples
 
+        RP66V1 name: *AXIS*
+
     element_limit : list(int)
         The maximum size of the sample dimensions
 
+        RP66V1 name: *ELEMENT-LIMIT*
+
     source
         The source of the channel. Returns the source object, if any
+
+        RP66V1 name: *SOURCE*
 
     frame : Frame
         Frame to which channel belongs to

--- a/python/dlisio/dlis/coefficient.py
+++ b/python/dlisio/dlis/coefficient.py
@@ -15,19 +15,29 @@ class Coefficient(BasicObject):
     label : str
         Identify the coefficient-role in the calibration process
 
+        RP66V1 name: *LABEL*
+
     coefficients : list
         Coefficients corresponding to the label
 
+        RP66V1 name: *COEFFICIENTS*
+
     references : list
         Nominal values for each coefficient
+
+        RP66V1 name: *REFERENCES*
 
     plus_tolerance : list
         Maximum value that a sample can exceed the reference and still be
         "within tolerance"
 
+        RP66V1 name: *PLUS-TOLERANCES*
+
     minus_tolerance : list
         Maximum value that a sample can fall below the reference and still
         be "within tolerance"
+
+        RP66V1 name: *MINUS-TOLERANCES*
 
     See also
     --------

--- a/python/dlisio/dlis/comment.py
+++ b/python/dlisio/dlis/comment.py
@@ -13,6 +13,8 @@ class Comment(BasicObject):
     text : list(str)
         Textual comments
 
+        RP66V1 name: *TEXT*
+
     See also
     --------
 

--- a/python/dlisio/dlis/computation.py
+++ b/python/dlisio/dlis/computation.py
@@ -26,22 +26,34 @@ class Computation(BasicObject):
     long_name : str or Longname
         Descriptive name of the computation
 
+        RP66V1 name: *LONG-NAME*
+
     properties : list(str)
         Property indicators that summarizes the characteristics of the
         computation and the processing that has occurred to produce it
 
+        RP66V1 name: *PROPERTIES*
+
     dimension : list(int)
         Array structure of a single value
 
+        RP66V1 name: *DIMENSION*
+
     axis : list(Axis)
         Coordinate axes of the values
+
+        RP66V1 name: *AXIS*
 
     zones : list(Zone)
         Mutually disjoint zones over which the value of the current
         computation is constant
 
+        RP66V1 name: *ZONES*
+
     source
         The immediate source of the Computation
+
+        RP66V1 name: *SOURCE*
 
     See also
     --------
@@ -112,7 +124,9 @@ class Computation(BasicObject):
         certain zone. If this is the case the first zone, computation.zones[0],
         will correspond to the first value, computation.values[0] and so on.
         If there is no zones, there should only be one value, which is said to
-        be unzoned, i.e. it is defined everywere.
+        be unzoned, i.e. it is defined everywhere.
+
+        RP66V1 name: *VALUES*
 
         Raises
         ------

--- a/python/dlisio/dlis/equipment.py
+++ b/python/dlisio/dlis/equipment.py
@@ -16,53 +16,87 @@ class Equipment(BasicObject):
     trademark_name : str
         The producer's name for the equipment
 
+        RP66V1 name: *TRADEMARK-NAME*
+
     status : bool
         Operational status
+
+        RP66V1 name: *STATUS*
 
     generic_type : str
         Generic type
 
+        RP66V1 name: *TYPE*
+
     serial_number : str
         Serial number
+
+        RP66V1 name: *SERIAL-NUMBER*
 
     location : str
         General location of equipment during acqusition
 
+        RP66V1 name: *LOCATION*
+
     height
         Heigth
+
+        RP66V1 name: *HEIGHT*
 
     length
         Length
 
+        RP66V1 name: *LENGTH*
+
     diameter_min
         Minimum diameter
+
+        RP66V1 name: *MINIMUM-DIAMETER*
 
     diameter_max
         Maximum diameter
 
+        RP66V1 name: *MAXIMUM-DIAMETER*
+
     volume
         Volume
+
+        RP66V1 name: *VOLUME*
 
     weight
         Weight
 
+        RP66V1 name: *WEIGHT*
+
     hole_size
         Hole size
+
+        RP66V1 name: *HOLE-SIZE*
 
     pressure
         Pressure
 
+        RP66V1 name: *PRESSURE*
+
     temperature
         Temperature
+
+        RP66V1 name: *TEMPERATURE*
 
     vertical_depth
         Vertical depth
 
+        RP66V1 name: *VERTICAL-DEPTH*
+
     radial_drift
         Radial drift
 
+        RP66V1 name: *RADIAL-DRIFT*
+
     angular_drift
         Angular drift
+
+        RP66V1 name: *ANGULAR-DRIFT*
 
     See also
     --------

--- a/python/dlisio/dlis/fileheader.py
+++ b/python/dlisio/dlis/fileheader.py
@@ -44,8 +44,12 @@ class Fileheader(BasicObject):
     sequencenr : str
         Sequential position of the logical file in a storage set
 
+        RP66V1 name: *SEQUENCE-NUMBER*
+
     id : str
         Descriptive identification of the logical file
+
+        RP66V1 name: *ID*
 
 
     See also

--- a/python/dlisio/dlis/frame.py
+++ b/python/dlisio/dlis/frame.py
@@ -36,8 +36,12 @@ class Frame(BasicObject):
     description : str
         Textual description of the Frame.
 
+        RP66V1 name: *DESCRIPTION*
+
     channels : list(Channel)
         Channels in the frame
+
+        RP66V1 name: *CHANNELS*
 
     index_type : str
         The measurement of the index, e.g. borehole-depth. If **not** None, the
@@ -45,20 +49,32 @@ class Frame(BasicObject):
         None, then the Frame has no index channel and is implicitly indexed by
         samplenumber i.e. 0, 1, ..., n.
 
+        RP66V1 name: *INDEX-TYPE*
+
     direction : str
         Direction of the index (Increasing or decreasing)
+
+        RP66V1 name: *DIRECTION*
 
     spacing
         Constant spacing in the index
 
+        RP66V1 name: *SPACING*
+
     index_min
         Minimum value of the index
+
+        RP66V1 name: *INDEX-MIN*
 
     index_max
         Maximum value of the index
 
+        RP66V1 name: *INDEX-MAX*
+
     encrypted : bool
         If the frame was encrypted
+
+        RP66V1 name: *ENCRYPTED*
 
     See also
     --------

--- a/python/dlisio/dlis/group.py
+++ b/python/dlisio/dlis/group.py
@@ -16,15 +16,23 @@ class Group(BasicObject):
 
     description : str
 
+        RP66V1 name: *DESCRIPTION*
+
     object_type  : str
         Specifies the type of object that is referenced in the object list
         attribute.
 
+        RP66V1 name: *OBJECT-TYPE*
+
     object_list : list
         References to arbitrary objects.
 
+        RP66V1 name: *OBJECT-LIST*
+
     group_list : list(Group)
         Reference to other Group objects
+
+        RP66V1 name: *GROUP-LIST*
 
     Notes
     -----

--- a/python/dlisio/dlis/longname.py
+++ b/python/dlisio/dlis/longname.py
@@ -13,52 +13,82 @@ class Longname(BasicObject):
     modifier : list(str)
         General modifier
 
+        RP66V1 name: *GENERAL-MODIFIER*
+
     quantity : str
         Something that is measureable E.g. the diameter of a pipe
 
+        RP66V1 name: *QUANTITY*
+
     quantity_mod : list(str)
         Specialization of a quantity
+
+        RP66V1 name: *QUANTITY-MODIFIER*
 
     altered_form : str
         Altered form of the quantity. E.g. standard deviation is an altered
         form of a temperature quantity.
 
+        RP66V1 name: *ALTERED-FORM*
+
     entity : str
         The entity of which the quantity is measured. E.g. entity =
         borehole, quantity = diameter
 
+        RP66V1 name: *ENTITY*
+
     entity_mod : list(str)
         Specialization of an entity
+
+        RP66V1 name: *ENTITY-MODIFIER*
 
     entity_nr : str
         Distinguishes multiple instances of the same entity
 
+        RP66V1 name: *ENTITY-NUMBER*
+
     entity_part : str
         Part of an entity
+
+        RP66V1 name: *ENTITY-PART*
 
     entity_part_nr : str
         Distinguishes multiple instances of the same entity part
 
+        RP66V1 name: *ENTITY-PART-NUMBER*
+
     generic_source : str
         The source of the information
+
+        RP66V1 name: *GENERIC-SOURCE*
 
     source_part : list(str)
         A specific part of the source information. E.g. "transmitter"
 
+        RP66V1 name: *SOURCE-PART*
+
     source_part_nr : list(str)
         Distinguishes multiple instances of the same source part
+
+        RP66V1 name: *SOURCE-PART-NUMBER*
 
     conditions : list(str)
         Conditions applicable at the time the information was acquired or
         generated
 
+        RP66V1 name: *CONDITIONS*
+
     standard_symbol : str
         Industry-standardized symbolic name by which the information is
         known. The possible values are specified by POSC
 
+        RP66V1 name: *STANDARD-SYMBOL*
+
     private_symbol : str
         Association between the recorded information and corresponding
         records or objects of the Producer’s internal or corporate database
+
+        RP66V1 name: *PRIVATE-SYMBOL*
 
 
     See also

--- a/python/dlisio/dlis/measurement.py
+++ b/python/dlisio/dlis/measurement.py
@@ -17,30 +17,48 @@ class Measurement(BasicObject):
     phase : str
         In what phase of the overall job sequence the measurement as acquired
 
+        RP66V1 name: *PHASE*
+
     source
         Source the measurement
+
+        RP66V1 name: *MEASUREMENT-SOURCE*
 
     mtype : str
         Type of measurement
 
+        RP66V1 name: *TYPE*
+
     dimension : list(int)
         Structure of the sample array
+
+        RP66V1 name: *DIMENSION*
 
     axis : list(Axis)
         Coordinate axis of the sample array
 
+        RP66V1 name: *AXIS*
+
     samplecount : int
         Number of samples used to compute the max/std_deviation
+
+        RP66V1 name: *SAMPLE-COUNT*
 
     begin_time
         Time of the sample acquisition. |crtime|
 
+        RP66V1 name: *BEGIN-TIME*
+
     duration
         Time duration of the sample acquisition
+
+        RP66V1 name: *DURATION*
 
     standard
         Measurable quantity of the calibration standard used to produce the
         sample
+
+        RP66V1 name: *STANDARD*
 
     See also
     --------
@@ -123,6 +141,8 @@ class Measurement(BasicObject):
 
         The type of measurment is described by the type attribute. Each sample
         may be either a scalar or ndarray
+
+        RP66V1 name: *MEASUREMENT*
         """
         try:
             samples = self.attic['MEASUREMENT'].value
@@ -143,6 +163,8 @@ class Measurement(BasicObject):
 
         Each sample may be a scalar of ndarray, but should have the same
         structure as the samples in the sample attribute.
+
+        RP66V1 name: *MAXIMUM-DEVIATION*
         """
         try:
             dev = self.attic['MAXIMUM-DEVIATION'].value
@@ -162,6 +184,8 @@ class Measurement(BasicObject):
 
         Each sample may be a scalar of ndarray, but should have the same
         structure as the samples in the sample attribute.
+
+        RP66V1 name: *STANDARD-DEVIATION*
         """
         try:
             dev = self.attic['STANDARD-DEVIATION'].value
@@ -177,6 +201,8 @@ class Measurement(BasicObject):
 
         Each sample may be a scalar of ndarray, but should have the same
         structure as the samples in the sample attribute.
+
+        RP66V1 name: *REFERENCE*
         """
         try:
             ref = self.attic['REFERENCE'].value
@@ -195,6 +221,8 @@ class Measurement(BasicObject):
 
         Each sample may be a scalar of ndarray, but should have the same
         structure as the samples in the sample attribute.
+
+        RP66V1 name: *PLUS-TOLERANCE*
         """
         try:
             tolerance = self.attic['PLUS-TOLERANCE'].value
@@ -213,6 +241,8 @@ class Measurement(BasicObject):
 
         Each sample may be a scalar of ndarray, but should have the same
         structure as the samples in the sample attribute.
+
+        RP66V1 name: *MINUS-TOLERANCE*
         """
         try:
             tolerance   = self.attic['MINUS-TOLERANCE'].value

--- a/python/dlisio/dlis/message.py
+++ b/python/dlisio/dlis/message.py
@@ -15,23 +15,37 @@ class Message(BasicObject):
     message_type : str
         source and purpose of the message.
 
+        RP66V1 name: *TYPE*
+
     time
         time the message was issued. |crtime|
+
+        RP66V1 name: *TIME*
 
     borehole_drift
         borehole drift of the tool zero point when message was issued.
 
+        RP66V1 name: *BOREHOLE-DRIFT*
+
     vertical_depth
         vertical depth of the tool zero point when message was issued.
+
+        RP66V1 name: *VERTICAL-DEPTH*
 
     radial_drift
         radial drift of the tool zero point when message was issued.
 
+        RP66V1 name: *RADIAL-DRIFT*
+
     angular_drift
         angular drift of the tool zero point when message was issued.
 
+        RP66V1 name: *ANGULAR-DRIFT*
+
     text : list(str)
         message(s).
+
+        RP66V1 name: *TEXT*
 
     See also
     --------

--- a/python/dlisio/dlis/noformat.py
+++ b/python/dlisio/dlis/noformat.py
@@ -15,8 +15,12 @@ class Noformat(BasicObject):
         Client-provided name for the data, for example an external file
         specification
 
+        RP66V1 name: *CONSUMER-NAME*
+
     description : str
         Textual description
+
+        RP66V1 name: *DESCRIPTION*
 
     See also
     --------

--- a/python/dlisio/dlis/origin.py
+++ b/python/dlisio/dlis/origin.py
@@ -22,66 +22,106 @@ class Origin(BasicObject):
     file_id : str
         An exact copy of Fileheader.id
 
+        RP66V1 name: *FILE-ID*
+
     file_set_name : str
         The name of the File Set that the Logical File is a part of
+
+        RP66V1 name: *FILE-SET-NAME*
 
     file_set_nr : int
         The number of the File Set that the Logical File is a part of
 
+        RP66V1 name: *FILE-SET-NUMBER*
+
     file_nr : int
         The file number of the Logical File within a File Set
+
+        RP66V1 name: *FILE-NUMBER*
 
     file_type : str
         A producer spesified File-Type that signifies the content of the
         DLIS-file
 
+        RP66V1 name: *FILE-TYPE*
+
     product : str
         Name of the software product that produced the DLIS-file
 
+        RP66V1 name: *PRODUCT*
+
     version : str
         The version of the software product that created the DLIS-file
+
+        RP66V1 name: *VERSION*
 
     programs : list(str)
         Other programs and services that was a part of the software that
         created the DLIS-file
 
+        RP66V1 name: *PROGRAMS*
+
     creation_time : datetime
         Date and time at which the DLIS-File was created
+
+        RP66V1 name: *CREATION-TIME*
 
     order_nr : str
         An unique accounting number assosiated with the creation of the
         DLIS-File
 
+        RP66V1 name: *ORDER-NUMBER*
+
     descent_nr
         The meaning of this number must be obtained directly from the producer
+
+        RP66V1 name: *DESCENT-NUMBER*
 
     run_nr
         The meaning of this number must be obtained directly from the company
 
+        RP66V1 name: *RUN-NUMBER*
+
     well_id
         Id of the well at which the measurements where acquired
+
+        RP66V1 name: *WELL-ID*
 
     well_name : str
         Name of the well at which the measurements where acquired
 
+        RP66V1 name: *WELL-NAME*
+
     field_name : str
         The field to which the well belongs
+
+        RP66V1 name: *FIELD-NAME*
 
     producer_code : int
         The producer's identifying code
 
+        RP66V1 name: *PRODUCER-CODE*
+
     producer_name : str
         The producer's name
 
+        RP66V1 name: *PRODUCER-NAME*
+
     company : str
         The name of the client company which the log was produced for
+
+        RP66V1 name: *COMPANY*
 
     namespace_name : str
         (DLIS internal) A producer-defined namespace for which the object names
         for this origin are defined under
 
+        RP66V1 name: *NAME-SPACE-NAME*
+
     namespace_version : int
         (DLIS internal) The version of the namespace.
+
+        RP66V1 name: *NAME-SPACE-VERSION*
 
     See also
     --------

--- a/python/dlisio/dlis/parameter.py
+++ b/python/dlisio/dlis/parameter.py
@@ -24,14 +24,22 @@ class Parameter(BasicObject):
     long_name : Longname
         Descriptive name of the channel.
 
+        RP66V1 name: *LONG-NAME*
+
     dimension : list(int)
         Dimensions of the parameter values
+
+        RP66V1 name: *DIMENSION*
 
     axis : list(Axis)
         Coordinate axes of the parameter values
 
+        RP66V1 name: *AXIS*
+
     zones : list(Zone)
         Mutually disjoint intervals where the parameter values is constant
+
+        RP66V1 name: *ZONES*
 
     See also
     --------
@@ -91,6 +99,8 @@ class Parameter(BasicObject):
         will correspond to the first value, parameter.values[0] and so on.  If
         there is no zones, there should only be one value, which is said to be
         unzoned, i.e. it is defined everywere.
+
+        RP66V1 name: *VALUES*
 
         Raises
         ------

--- a/python/dlisio/dlis/path.py
+++ b/python/dlisio/dlis/path.py
@@ -16,45 +16,67 @@ class Path(BasicObject):
     frame_type : Frame
         The frame in which the channel's of the current path are recorded.
 
+        RP66V1 name: *FRAME-TYPE*
+
     well_reference_point : Wellref
         Well Reference Point
 
+        RP66V1 name: *WELL-REFERENCE-POINT*
+
     value : list(Channel)
         Value Channel for the current Path.
+
+        RP66V1 name: *VALUE*
 
     borehole_depth
         Specifies the constant Borehole Depth coordinate for the
         current Path, It may or may not be described by a channel object.
 
+        RP66V1 name: *BOREHOLE-DEPTH*
+
     vertical_depth
         Specifies the constant Vertical Depth coordinate for the
         current Path, It may or may not be described by a channel object.
+
+        RP66V1 name: *VERTICAL-DEPTH*
 
     radial_drift
         Specifies the constant Radial Drift coordinate for the
         current Path, It may or may not be described by a channel object.
 
+        RP66V1 name: *RADIAL-DRIFT*
+
     angular_drift
         Specifies the constant Angular Drift coordinate for the
         current Path, It may or may not be described by a channel object.
+
+        RP66V1 name: *ANGULAR-DRIFT*
 
     time
         Specifies the constant Time coordinate for the
         current Path, It may or may not be described by a channel object.
         |crtime|
 
+        RP66V1 name: *TIME*
+
     depth_offset
         Specifies the Depth Offset, which indicates how much the *value*
         is "off depth".
+
+        RP66V1 name: *DEPTH-OFFSET*
 
     measure_point_offset
         Specifies a Measure Point Offset, which indicates a fixed distance
         along Borehole Depth from the Value Channel’s Measure Point to a
         Data Reference Point.
 
+        RP66V1 name: *MEASURE-POINT-OFFSET*
+
     tool_zero_offset
         Distance of the Data Reference Point for the current Path above
         the tool string’s Tool Zero Point.
+
+        RP66V1 name: *TOOL-ZERO-OFFSET*
 
 
     See also

--- a/python/dlisio/dlis/process.py
+++ b/python/dlisio/dlis/process.py
@@ -14,39 +14,61 @@ class Process(BasicObject):
 
     description : str
 
+        RP66V1 name: *DESCRIPTION*
+
     trademark_name  : str
         Trademark name refers to the process and its products.
 
+        RP66V1 name: *TRADEMARK-NAME*
+
     version : str
         Software version.
+
+        RP66V1 name: *VERSION*
 
     properties : list(str)
         Properties that applies to the output of the process, as a result of
         the process.
 
+        RP66V1 name: *PROPERTIES*
+
     status : str
         Indicated the status of the process. It's typically updated to indicate
         when the process is completed or aborted.
 
+        RP66V1 name: *STATUS*
+
     input_channels : list(Channel)
         Channels that are used directly by this Process.
+
+        RP66V1 name: *INPUT-CHANNELS*
 
     output_channels : list(Channel)
         Channels that are produced directly by this Process.
 
+        RP66V1 name: *OUTPUT-CHANNELS*
+
     input_computations : list(Computation)
         Computations that are used directly by this Process.
 
+        RP66V1 name: *INPUT-COMPUTATIONS*
+
     output_computations : list(Computation)
         Computations that are produced directly by this Process.
+
+        RP66V1 name: *OUTPUT-COMPUTATIONS*
 
     parameters : list(Parameter)
         Parameters that are used by the Process or that directly affect the
         operation of the Process.
 
+        RP66V1 name: *PARAMETERS*
+
     comments : list(str)
         Comments contains information specific to the particular
         execution of the process.
+
+        RP66V1 name: *COMMENTS*
 
     See also
     --------

--- a/python/dlisio/dlis/splice.py
+++ b/python/dlisio/dlis/splice.py
@@ -28,13 +28,19 @@ class Splice(BasicObject):
     ----------
 
     output_channel : Channel
-        Concatination of all input channels
+        Concatenation of all input channels
+
+        RP66V1 name: *OUTPUT-CHANNELS*
 
     input_channels : list(Channel)
         Channels that where used to create the output channel
 
-    Zones : list(Zone)
+        RP66V1 name: *INPUT-CHANNELS*
+
+    zones : list(Zone)
         Zones of each input channel that is used in the concatination process
+
+        RP66V1 name: *ZONES*
 
     See also
     --------

--- a/python/dlisio/dlis/tool.py
+++ b/python/dlisio/dlis/tool.py
@@ -16,23 +16,37 @@ class Tool(BasicObject):
     description : str
         Textual description of the tool
 
+        RP66V1 name: *DESCRIPTION*
+
     trademark_name : str
         The producer's name for the tool
+
+        RP66V1 name: *TRADEMARK-NAME*
 
     generic_name : str
         The name generally used by the industry to describe such a tool
 
+        RP66V1 name: *GENERIC-NAME*
+
     status : bool
         If the tool is enabled to provide information to the acquisition system
+
+        RP66V1 name: *STATUS*
 
     parts : list(Equipment)
         Equipments that makes up the tool
 
+        RP66V1 name: *PARTS*
+
     channels : list(Channel)
         Channels that are produced by this tool
 
+        RP66V1 name: *CHANNELS*
+
     parameters : list(Parameter)
         Parameters that directly affect or reflect the operation of the tool
+
+        RP66V1 name: *PARAMETERS*
 
     See also
     --------

--- a/python/dlisio/dlis/wellref.py
+++ b/python/dlisio/dlis/wellref.py
@@ -14,25 +14,39 @@ class Wellref(BasicObject):
     permanent_datum : str
         Level from where vertical distance is measured
 
+        RP66V1 name: *PERMANENT-DATUM*
+
     vertical_zero : str
         Vertical zero is an entity that corresponds to zero depth.
+
+        RP66V1 name: *VERTICAL-ZERO*
 
     permanent_datum_elevation
         Permanent datum, structure or entity from which the vertical distance
         can be measured.
 
+        RP66V1 name: *PERMANENT-DATUM-ELEVATION*
+
     above_permanent_datum
         Distance of permanent Datum above mean sea level. Negative values
         indicates that the Permanent datum is below mean sea level
+
+        RP66V1 name: *ABOVE-PERMANENT-DATUM*
 
     magnetic_declination
         Angle between  the line of direction to geographic north and the line
         of direction to magnetic north. This defines angle with vertex at well
         reference point.
 
+        RP66V1 name: *MAGNETIC-DECLINATION*
+
     coordinate : dict
         Independent spatial coordinates. Typically, latitude, longitude and
         elevation
+
+        RP66V1 names: *COORDINATE-1-NAME*, *COORDINATE-1-VALUE*,
+        *COORDINATE-2-NAME*, *COORDINATE-2-VALUE*, *COORDINATE-3-NAME*,
+        *COORDINATE-3-VALUE*
 
     See also
     --------

--- a/python/dlisio/dlis/zone.py
+++ b/python/dlisio/dlis/zone.py
@@ -14,12 +14,23 @@ class Zone(BasicObject):
     ----------
     description : str
         Description of the zone
+
+        RP66V1 name: *DESCRIPTION*
+
     domain : str
         Type of interval, e.g. borhole-depth, time or vertical-depth
+
+        RP66V1 name: *DOMAIN*
+
     maximum
         Latest time or deepest point, not inclusive
+
+        RP66V1 name: *MAXIMUM*
+
     minimum
         Earliest time or shallowest point, inclusive
+
+        RP66V1 name: *MINIMUM*
 
     See also
     --------

--- a/python/docs/dlis/metadata.rst
+++ b/python/docs/dlis/metadata.rst
@@ -92,6 +92,37 @@ to make it easy to work with programmatically:
    >>> channel.long_name
    'Bond Index'
 
+Units
+-----
+
+Alongside attribute values, a DLIS-file also contains a corresponding **units**
+field. This is true for all object attributes, even when units make little
+sense, such as for :attr:`Channel.long_name`.
+
+Currently there is no *nice* interface for accessing units with dlisio.
+They are, however, reachable through some of the more basic interfaces.
+Sensible units are also printed in :func:`BasicObject.describe`.
+
+Each metadata object has in itself an attribute attic,
+:attr:`BasicObject.attic`.
+The attic is a complete dict-like representation of the object, but without the
+syntactic sugar provided by the specialized class of the object.
+
+At the moment attribute units are only accessible through the attic:
+:code:`obj.attic['ATTRIBUTE'].units`.
+
+Every attribute has a *RP66V1 name* section in its docs that corresponds to
+the :code:`ATTRIBUTE` value, which must be used to retrieve the raw attribute.
+
+For example, given the object :code:`frame` and docs for :attr:`Frame.spacing`:
+
+.. code-block:: python
+
+   >>> frame.spacing
+   ... 800
+   >>> frame.attic['SPACING'].units
+   ... '0.5 ms'
+
 Multiple origins
 ----------------
 


### PR DESCRIPTION
While we struggle with creating good interface for units in current
design, units are actually already accessible to the users, though few
may know about it.

As this feature appears to be quite important, it makes sense to
properly document at least the "back door" access to it.