### PR TITLE
Support non-ASCII characters in filepath

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(dlisio src/dlis/dlisio.cpp
                    src/lis/types.cpp
                    src/lis/pack.cpp
                    src/lis/io.cpp
-                   src/stream.cpp
+                   src/file.cpp
                    src/tapemark.cpp
 )
 target_include_directories(dlisio

--- a/lib/include/dlisio/dlis/io.hpp
+++ b/lib/include/dlisio/dlis/io.hpp
@@ -9,7 +9,7 @@
 
 #include <lfp/lfp.h>
 
-#include <dlisio/stream.hpp>
+#include <dlisio/file.hpp>
 #include <dlisio/dlis/types.hpp>
 #include <dlisio/dlis/records.hpp>
 

--- a/lib/include/dlisio/file.hpp
+++ b/lib/include/dlisio/file.hpp
@@ -2,6 +2,7 @@
 #define DLISIO_FILE_HPP
 
 #include <cstdint>
+#include <cstdio>
 
 #include <lfp/lfp.h>
 
@@ -70,6 +71,9 @@ public:
 private:
     lfp_protocol* f;
 };
+
+/* Opens a file in 'rb' mode */
+std::FILE* fopen( const char* path ) noexcept (false);
 
 } // namespace dlisio
 

--- a/lib/include/dlisio/file.hpp
+++ b/lib/include/dlisio/file.hpp
@@ -1,5 +1,5 @@
-#ifndef DLISIO_STREAM_HPP
-#define DLISIO_STREAM_HPP
+#ifndef DLISIO_FILE_HPP
+#define DLISIO_FILE_HPP
 
 #include <cstdint>
 
@@ -73,4 +73,4 @@ private:
 
 } // namespace dlisio
 
-#endif // DLISIO_STREAM_HPP
+#endif // DLISIO_FILE_HPP

--- a/lib/include/dlisio/lis/io.hpp
+++ b/lib/include/dlisio/lis/io.hpp
@@ -9,7 +9,7 @@
 #include <lfp/tapeimage.h>
 
 #include <dlisio/lis/protocol.hpp>
-#include <dlisio/stream.hpp>
+#include <dlisio/file.hpp>
 
 
 namespace dlisio { namespace lis79 {

--- a/lib/include/dlisio/tapemark.hpp
+++ b/lib/include/dlisio/tapemark.hpp
@@ -1,7 +1,7 @@
 #ifndef DLISIO_TAPEMARK_HPP
 #define DLISIO_TAPEMARK_HPP
 
-#include <dlisio/stream.hpp>
+#include <dlisio/file.hpp>
 
 /** tapemark.hpp - Tape Image Format
  *

--- a/lib/src/dlis/io.cpp
+++ b/lib/src/dlis/io.cpp
@@ -26,7 +26,7 @@ namespace dlisio { namespace dlis {
 
 dlisio::stream open(const std::string& path, std::int64_t offset)
 noexcept (false) {
-    auto* file = std::fopen(path.c_str(), "rb");
+    auto* file = dlisio::fopen(path.c_str());
     if (!file) {
         auto msg = "unable to open file for path {} : {}";
         throw dlisio::io_error(fmt::format(msg, path, strerror(errno)));

--- a/lib/src/dlis/io.cpp
+++ b/lib/src/dlis/io.cpp
@@ -13,7 +13,7 @@
 #include <lfp/rp66.h>
 #include <lfp/tapeimage.h>
 
-#include <dlisio/stream.hpp>
+#include <dlisio/file.hpp>
 #include <dlisio/exception.hpp>
 
 #include <dlisio/dlis/dlisio.h>

--- a/lib/src/file.cpp
+++ b/lib/src/file.cpp
@@ -3,7 +3,7 @@
 
 #include <lfp/lfp.h>
 
-#include <dlisio/stream.hpp>
+#include <dlisio/file.hpp>
 
 namespace dlisio {
 

--- a/lib/src/file.cpp
+++ b/lib/src/file.cpp
@@ -1,5 +1,12 @@
 #include <stdexcept>
 #include <cstdint>
+#include <cstdio>
+#include <string>
+#include <cassert>
+
+#ifdef _WIN32
+    #include <windows.h>
+#endif
 
 #include <lfp/lfp.h>
 
@@ -77,6 +84,33 @@ int stream::peof() const noexcept (false) {
         }
         outer = inner;
     }
+}
+
+std::FILE* fopen( const char* path) noexcept (false) {
+    std::FILE* file;
+
+#ifdef _WIN32
+    auto wpathlen = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
+
+    /* can in theory fail if path contains illegal characters, though it is
+     * unlikely in practice
+     */
+    if (wpathlen <= 0) {
+        const auto msg = "dlisio::sysopen: unable to count wpath length";
+        throw std::runtime_error(msg);
+    }
+
+    std::wstring wpath;
+    wpath.resize(wpathlen);
+    auto written =
+        MultiByteToWideChar(CP_UTF8, 0, path, -1, &wpath[0], wpathlen);
+    assert(written == wpathlen);
+    file = _wfopen(wpath.c_str(), L"rb");
+#else
+    file = std::fopen(path, "rb");
+#endif
+
+    return file;
 }
 
 } // namespace dlisio

--- a/lib/src/lis/io.cpp
+++ b/lib/src/lis/io.cpp
@@ -576,7 +576,7 @@ iodevice::read_records(const record_index& index,
 /* miscellaneous */
 iodevice open( const std::string& path, std::int64_t offset, bool tapeimage )
 noexcept (false) {
-    auto* file = std::fopen(path.c_str(), "rb");
+    auto* file = dlisio::fopen(path.c_str());
     if ( not file ) {
         auto msg = "lis::open: unable to open file for path {} : {}";
         throw dlisio::io_error(fmt::format(msg, path, strerror(errno)));

--- a/lib/src/lis/io.cpp
+++ b/lib/src/lis/io.cpp
@@ -12,7 +12,7 @@
 
 #include <dlisio/lis/protocol.hpp>
 #include <dlisio/lis/io.hpp>
-#include <dlisio/stream.hpp>
+#include <dlisio/file.hpp>
 #include <dlisio/exception.hpp>
 
 namespace dlisio { namespace lis79 {

--- a/lib/src/tapemark.cpp
+++ b/lib/src/tapemark.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 
 #include <dlisio/tapemark.hpp>
-#include <dlisio/stream.hpp>
+#include <dlisio/file.hpp>
 #include <dlisio/exception.hpp>
 
 namespace dlisio {

--- a/python/dlisio/ext/dlis.cpp
+++ b/python/dlisio/ext/dlis.cpp
@@ -14,7 +14,7 @@
 #include <pybind11/stl.h>
 #include <datetime.h>
 
-#include <dlisio/stream.hpp>
+#include <dlisio/file.hpp>
 #include <dlisio/exception.hpp>
 #include <dlisio/dlis/dlisio.h>
 #include <dlisio/dlis/types.h>

--- a/python/tests/dlis/test_loading.py
+++ b/python/tests/dlis/test_loading.py
@@ -153,6 +153,17 @@ def test_load_nonexisting_file():
     msg = "'this_file_does_not_exist.dlis' is not an existing regular file"
     assert msg in str(exc.value)
 
+@pytest.mark.parametrize('id', [
+    "æøå",
+    "кириллица",
+    ])
+def test_file_with_nonascii_name(tmpdir, id):
+    path = str(tmpdir.join('file with '+id+'.dlis'))
+    shutil.copyfile('data/chap4-7/many-logical-files.dlis', path)
+
+    with dlis.load(path) as files:
+        assert len(files) == 3
+
 def test_load_directory():
     with pytest.raises(OSError) as exc:
         _ = dlis.load(".")

--- a/python/tests/lis/test_loading.py
+++ b/python/tests/lis/test_loading.py
@@ -60,6 +60,17 @@ def test_load_nonexisting_file():
     msg = "unable to open file for path this_file_does_not_exist.lis"
     assert msg in str(exc.value)
 
+@pytest.mark.parametrize('id', [
+    "中国文字",
+    "ąęóćłńśźżçè",
+    ])
+def test_file_with_nonascii_name(tmpdir, id):
+    path = str(tmpdir.join('file with '+id+'.lis'))
+    shutil.copyfile('data/lis/layouts/layout_tif_01.lis', path)
+
+    with lis.load(path) as files:
+        assert len(files) == 4
+
 def test_load_empty_file(tmpdir, merge_lis_prs):
     fpath = os.path.join(str(tmpdir), 'empty.lis')
     merge_lis_prs(fpath, [])


### PR DESCRIPTION
On all modern platforms, but Windows prior to recent years, file-name
string passed to fopen is interpreted as UTF-8 [1].
Known and common workaround that suits to all Windows versions is to use
MultiByteToWideChar function.

[1] https://en.wikipedia.org/wiki/Unicode_in_Microsoft_Windows#UTF-8