### PR TITLE
upated links to energistics for rp66v1 and lis-79

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 dlisio is an LGPL licensed library for reading well logs in Digital Log
 Interchange Standard (DLIS V1), also known as [RP66
-V1](http://w3.energistics.org/rp66/v1/Toc/main.html), and Log Information
-Standard 79 ([LIS79](http://w3.energistics.org/LIS/lis-79.pdf)).
+V1](https://www.energistics.org/sites/default/files/2023-03/rp66v1.html), and Log Information
+Standard 79 ([LIS79](https://www.energistics.org/sites/default/files/2022-10/lis-79.pdf)).
 
 dlisio is designed as a general purpose library for reading well logs in a
 simple and easy-to-use manner. Its main focus is making all the data and


### PR DESCRIPTION
failed for me when searching, found at https://www.energistics.org/hosted-standards