### PR TITLE
Add Read the Docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: python/docs/conf.py
+
+python:
+  install:
+  - requirements: python/requirements-dev.txt


### PR DESCRIPTION
Read the Docs from now on requires a configuration file to build.
It is unclear though how we can nicely test it works before we merge it...