### PR TITLE
Numpy 2.0

### DIFF
--- a/.github/workflows/analyzers.yaml
+++ b/.github/workflows/analyzers.yaml
@@ -11,7 +11,7 @@ jobs:
   cppcheck:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: './.github/actions/build_core_dependencies'
         with:
@@ -41,7 +41,7 @@ jobs:
   scan_build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: './.github/actions/build_core_dependencies'
         with:
@@ -69,7 +69,7 @@ jobs:
   valgrind:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: './.github/actions/build_core_dependencies'
         with:
@@ -96,7 +96,7 @@ jobs:
   debug:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: './.github/actions/build_core_dependencies'
         with:

--- a/.github/workflows/bigendian.yaml
+++ b/.github/workflows/bigendian.yaml
@@ -14,17 +14,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -27,7 +27,7 @@ jobs:
             cmake_generator: "-G \"Visual Studio 16 2019\" -A Win32"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Elevate privileges
         if: ${{ !contains( matrix.os, 'windows') }}

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11]
+        os: [macos-13, macos-14]
         include:
           - os: ubuntu-20.04
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,0 +1,62 @@
+name: Build and test python
+#Build and test with python turned on
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build_python:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: "./.github/actions/build_core_dependencies"
+        with:
+          privileges: "sudo"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Create python venv
+        shell: bash
+        run: |
+          python -m venv venv
+          . ./venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          python -m pip install -r python/requirements-dev.txt
+          which python
+
+      - name: Configure dlisio
+        shell: bash
+        run: |
+          . ./venv/bin/activate
+          cmake -S . -B build                     \
+            -DCMAKE_BUILD_TYPE=Release            \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON  \
+            -DBUILD_PYTHON=ON
+
+      - name: Build dlisio
+        shell: bash
+        run: |
+          sudo cmake   \
+            --build build     \
+            --parallel        \
+            --config Release
+
+      - name: Test dlisio
+        shell: bash
+        run: |
+          cd build
+          ctest -C Release --output-on-failure --verbose

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -30,9 +30,9 @@ jobs:
             arch: aarch64
           - os: ubuntu-20.04
             arch: i686
-          - os: macos-11
+          - os: macos-13
             arch: x86_64
-          - os: macos-13-xlarge
+          - os: macos-14
             arch: arm64
 
     steps:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -40,14 +40,14 @@ jobs:
         run: |
             git config --global core.autocrlf false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
-      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-qemu-action@v3
         if: ${{ matrix.arch == 'aarch64' }}
         name: Set up QEMU
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v3
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -29,7 +29,7 @@ jobs:
           - os: ubuntu-20.04
             arch: aarch64
           - os: ubuntu-20.04
-            arch: i686
+            arch: i686 #builds from cibuildwheel, qemu not needed
           - os: macos-13
             arch: x86_64
           - os: macos-14

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -68,7 +68,8 @@ jobs:
           # musllinux arch skip: unlikely someone wants to run dlisio on alpine on non-standard architecture
           # musllinux cp38 skip: latest available numpy doesn't provide musslinux wheels, so it is unlikely useful
           # macosx arm 38 skip: cibuildwheel can't test it
-          CIBW_SKIP: pp* *-musllinux_i686 *-musllinux_aarch64 cp38*-musllinux* cp38*-macosx_*arm64 cp36-* cp37-*
+          # 36, 37, 313 skip: python versions not supported
+          CIBW_SKIP: pp* *-musllinux_i686 *-musllinux_aarch64 cp38*-musllinux* cp38*-macosx_*arm64 cp36-* cp37-* cp313-*
 
         run: |
             python -m cibuildwheel --output-dir wheelhouse python/

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -67,8 +67,8 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           # musllinux arch skip: unlikely someone wants to run dlisio on alpine on non-standard architecture
           # musllinux cp38 skip: latest available numpy doesn't provide musslinux wheels, so it is unlikely useful
-          # macosx 38 skip: cibuildwheel can't test it
-          CIBW_SKIP: pp* *-musllinux_i686 *-musllinux_aarch64 cp38*-musllinux* cp38*-macosx_*:arm64 cp36-* cp37-*
+          # macosx arm 38 skip: cibuildwheel can't test it
+          CIBW_SKIP: pp* *-musllinux_i686 *-musllinux_aarch64 cp38*-musllinux* cp38*-macosx_*arm64 cp36-* cp37-*
 
         run: |
             python -m cibuildwheel --output-dir wheelhouse python/

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -66,9 +66,9 @@ jobs:
 
           CIBW_ARCHS: ${{ matrix.arch }}
           # musllinux arch skip: unlikely someone wants to run dlisio on alpine on non-standard architecture
-          # musllinux cp37 and cp38 skip: latest available numpy doesn't provide musslinux wheels, so it is unlikely useful
+          # musllinux cp38 skip: latest available numpy doesn't provide musslinux wheels, so it is unlikely useful
           # macosx 38 skip: cibuildwheel can't test it
-          CIBW_SKIP: pp* *-musllinux_i686 *-musllinux_aarch64 cp37*-musllinux* cp38*-musllinux* cp38*-macosx_*:arm64 cp36-*
+          CIBW_SKIP: pp* *-musllinux_i686 *-musllinux_aarch64 cp38*-musllinux* cp38*-macosx_*:arm64 cp36-* cp37-*
 
         run: |
             python -m cibuildwheel --output-dir wheelhouse python/

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -73,8 +73,9 @@ jobs:
         run: |
             python -m cibuildwheel --output-dir wheelhouse python/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   publish:
@@ -85,7 +86,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          merge-multiple: true
+          path: ./wheelhouse/
 
       - name: Publish wheels to PyPI
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ pip install dlisio
 
 |   | macOS Intel | macOS ARM | Windows 64bit | Windows 32bit | manylinux x86_64 | manylinux aarch64 | manylinux i686 | musllinux x86_64
 |---------------|----|-----|-----|----|----|----|----|----|
-| CPython 3.7   | ✅ | -   | ✅  | ✅ | ✅ | ✅ | ✅ | -  |
 | CPython 3.8   | ✅ | -   | ✅  | ✅ | ✅ | ✅ | ✅ | -  |
 | CPython 3.9   | ✅ | ✅  | ✅  | ✅ | ✅ | ✅ | ✅ | ✅ |
 | CPython 3.10  | ✅ | ✅  | ✅  | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -97,7 +96,7 @@ To develop dlisio, or to build a particular revision from source, you need:
 
 * A C++11 compatible compiler (tested on gcc, clang, and msvc 2019)
 * [CMake](https://cmake.org/) version 3.5 or greater
-* [Python](https://python.org) version 3.7 or greater
+* [Python](https://python.org) version 3.8 or greater
 * [fmtlib](http://fmtlib.net/) tested mainly with 7.1.3
 * [mpark_variant](https://github.com/mpark/variant)
 * [pybind11](https://github.com/pybind/pybind11) version 2.6 or greater

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To develop dlisio, or to build a particular revision from source, you need:
 * [pybind11](https://github.com/pybind/pybind11) version 2.6 or greater
 * [setuptools](https://pypi.python.org/pypi/setuptools) version 28 or greater
 * [layered-file-protocols](https://github.com/equinor/layered-file-protocols)
-* python packages pytest, pytest-runner, and numpy
+* python packages pytest and numpy
 
 If you do not have pybind11 installed on your system, the easiest way to get a
 working copy is to `pip3 install pybind11` (NP! pybind11, not pybind)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -137,6 +137,6 @@ endif()
 # different args to setup.py, rebuilding the python lib (and wrongly so as it
 # either won't find dlisio or picked up on a system installed one)
 add_test(NAME python.unit
-    COMMAND ${python} ${setup.py} --skip-cmake test
+    COMMAND ${python} -m pytest tests
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/python/dlisio/__init__.py
+++ b/python/dlisio/__init__.py
@@ -3,18 +3,8 @@ from . import common
 from . import lis
 from . import dlis
 
-import sys
-
-# remove else once support for python 3.7 is over
-if sys.version_info >= (3, 8):
-    try:
-        import importlib.metadata
-        __version__ = importlib.metadata.version(__name__)
-    except importlib.metadata.PackageNotFoundError:
-        pass
-else:
-    try:
-       import pkg_resources
-       __version__ = pkg_resources.get_distribution(__name__).version
-    except pkg_resources.DistributionNotFound:
-        pass
+try:
+    import importlib.metadata
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    pass

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "scikit-build",
     "wheel",
     "pybind11",
-    "pytest-runner",
 ]
 
 [tool.cibuildwheel]

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,6 +1,6 @@
 
 bandit
-numpy<2.0
+numpy
 setuptools
 setuptools_scm
 pytest

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -4,7 +4,6 @@ numpy
 setuptools
 setuptools_scm
 pytest
-pytest-runner
 pybind11
 hypothesis
 sphinx

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,5 +1,2 @@
 [metadata]
 version = 1.0.1
-
-[aliases]
-test = pytest

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ skbuild.setup(
     packages = ['dlisio', 'dlisio.dlis', 'dlisio.lis', 'dlisio.common', 'dlisio.dlis.utils'],
     license = 'LGPL-3.0',
     platforms = 'any',
-    install_requires = ['numpy < 2.0'],
+    install_requires = ['numpy'],
     setup_requires = ['setuptools >= 28',
                       'pybind11 >= 2.3',
                       'setuptools_scm',

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,6 @@
 
 import os
 import skbuild
-import setuptools
 
 class get_pybind_include(object):
     def __init__(self, user=False):
@@ -54,7 +53,4 @@ skbuild.setup(
         # supported OS X release 10.9
         '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9',
     ],
-    # skbuild's test imples develop, which is pretty obnoxious instead, use a
-    # manually integrated pytest.
-    cmdclass = { 'test': setuptools.command.test.test },
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,9 +39,7 @@ skbuild.setup(
     setup_requires = ['setuptools >= 28',
                       'pybind11 >= 2.3',
                       'setuptools_scm',
-                      'pytest-runner',
     ],
-    tests_require = ['pytest'],
     # we're building with the pybind11 fetched from pip. Since we don't rely on
     # a cmake-installed pybind there's also no find_package(pybind11) -
     # instead, the get include dirs from the package and give directly from


### PR DESCRIPTION
Planning to test wheels before making a release, but think it should be ok.

Update:
1. Setuptools just removed test command https://github.com/pypa/setuptools/commit/4c0b9f3ee6ee47c597572655567f215c08c90137
Change is in 72.0, now 70.1 or something near it is picked up, so surprise might yet to come
2. pytest-runner is deprecated. Will have to deal with it somehow
https://pytest-runner.readthedocs.io/en/latest/index.html
3. Invoking with python setup.py is deprecated, which is a problem, need to figure out what to do now.
https://packaging.python.org/en/latest/discussions/setup-py-deprecated/
Last two points rather not in this PR.

Update 2:
- flow that is affected by setuptools test command is not really in CI (it would be discovered by bigendian job, if setuptools there were updated)
- yes, we fail with newest setuptools (though there is already a version where test command is restored). That is about `Unknown distribution option: 'tests_require'`, but I am not sure if it is our test_require problem or if it is skbuild problem or if it is still setuptools didn't revert something back. I think that even if I don't pin setuptools, nothing should fail here (bigendian anyway using old version). But the issue should be addressed later anyway.

Update 3:
Seems like it is our test-require that breaks setuptools. If whole "remove python setup.py test" thing is done, looks like new setuptools works fine.