### PR TITLE
Update GitHub runners

### DIFF
--- a/.github/workflows/analyzers.yaml
+++ b/.github/workflows/analyzers.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cppcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +39,7 @@ jobs:
             --project=build/compile_commands.json           \
 
   scan_build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -67,7 +67,7 @@ jobs:
             --target install
 
   valgrind:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -94,7 +94,7 @@ jobs:
             valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 build/lib/test-lis
 
   debug:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -20,11 +20,11 @@ jobs:
           - os: ubuntu-latest
             compiler: "clang"
 
-          - os: windows-2019
-            cmake_generator: "-G \"Visual Studio 16 2019\" -A x64"
+          - os: windows-2022
+            cmake_generator: "-G \"Visual Studio 17 2022\" -A x64"
 
-          - os: windows-2019
-            cmake_generator: "-G \"Visual Studio 16 2019\" -A Win32"
+          - os: windows-2022
+            cmake_generator: "-G \"Visual Studio 17 2022\" -A Win32"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         os: [macos-13, macos-14]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
 
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             compiler: "clang"
 
           - os: windows-2019

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             arch: AMD64
-            cmake_generator: "Visual Studio 16 2019"
+            cmake_generator: "Visual Studio 17 2022"
             cmake_generator_platform: "x64"
-          - os: windows-2019
+          - os: windows-2022
             arch: x86
-            cmake_generator: "Visual Studio 16 2019"
+            cmake_generator: "Visual Studio 17 2022"
             cmake_generator_platform: "Win32"
           - os: ubuntu-latest
             arch: x86_64

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -24,11 +24,11 @@ jobs:
             arch: x86
             cmake_generator: "Visual Studio 16 2019"
             cmake_generator_platform: "Win32"
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             arch: x86_64
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             arch: aarch64
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             arch: i686 #builds from cibuildwheel, qemu not needed
           - os: macos-13
             arch: x86_64


### PR DESCRIPTION
GitHub's Ubuntu 20.04 runners have been deprecated since 2025-05-14 [1]. The runners are updated to use the `ubuntu-latest` image. The only exception is the `aarch64` build on Linux that uses `ubuntu-24.04-arm` which an `aarch64` runner which allows to build the wheels without emulation speeding up the build process.

[1]: https://github.com/actions/runner-images/issues/11101